### PR TITLE
Add MFA mock endpoint

### DIFF
--- a/config/packages/test/services.yaml
+++ b/config/packages/test/services.yaml
@@ -1,0 +1,20 @@
+services:
+    # default configuration for services in *this* file
+    _defaults:
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+
+    # makes classes in src/ available to be used as services
+    # this creates a service per class whose id is the fully-qualified class name
+    Dev\:
+        resource: '../../../dev/*'
+        exclude: '../../../dev/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}'
+
+    # controllers are imported separately to make sure services can be injected
+    # as action arguments even if you don't extend any base controller class
+    Dev\Controller\:
+        resource: '../../../dev/Controller'
+        tags: ['controller.service_arguments']
+
+    # add more service definitions when explicit configuration is needed
+    # please note that last definitions always *replace* previous ones

--- a/config/packages/test/surfnet_saml.yaml
+++ b/config/packages/test/surfnet_saml.yaml
@@ -6,12 +6,23 @@ surfnet_saml:
       sso_route: gssp_saml_sso
       public_key: "%saml_idp_publickey%"
       private_key: "%saml_idp_privatekey%"
+    service_provider:
+      enabled: true
+      assertion_consumer_route: sp_demo_acs
+      public_key: "%saml_idp_publickey%"
+      private_key: "%saml_idp_privatekey%"
     metadata:
       entity_id_route: gssp_saml_metadata
       public_key: "%saml_metadata_publickey%"
       private_key: "%saml_metadata_privatekey%"
   remote:
     service_providers:
+      - entity_id: "%saml_remote_sp_entity_id%"
+        certificate_file: "%saml_remote_sp_certificate%"
+        assertion_consumer_service_url: "%saml_remote_sp_acs%"
       - entity_id: https://service_provider/saml/metadata
         certificate_file: "%saml_remote_sp_certificate%"
         assertion_consumer_service_url: https://service_provider/saml/sso_return
+      - entity_id: https://azure-mfa.stepup.example.com/saml/metadata
+        certificate_file: "%saml_idp_publickey%"
+        assertion_consumer_service_url: https://azure-mfa.stepup.example.com/demo/sp/acs

--- a/config/routes/test/demo.yaml
+++ b/config/routes/test/demo.yaml
@@ -1,0 +1,3 @@
+controllers:
+    resource: ../../../dev/Controller/
+    type: annotation

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -21,3 +21,10 @@ services:
     Surfnet\AzureMfa\Infrastructure\Institution\ConfigurationValidator:
         arguments:
             $configuration: '%institution_configuration%'
+
+    Dev\Mock\MockConfiguration:
+        arguments:
+            $identityProviderEntityId: 'https://azure-mfa.stepup.example.com/mock/idp/metadata'
+            $serviceProviderEntityId: 'https://azure-mfa.stepup.example.com/saml/metadata'
+            $privateKeyPath: '%saml_idp_privatekey%'
+            $publicCertPath: '%saml_idp_publickey%'

--- a/dev/Controller/MockAzureMfaController.php
+++ b/dev/Controller/MockAzureMfaController.php
@@ -1,0 +1,151 @@
+<?php declare(strict_types = 1);
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Dev\Controller;
+
+use Dev\Mock\MockGateway;
+use Exception;
+use SAML2\Constants;
+use SAML2\Response as SamlResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Twig\Environment;
+
+class MockAzureMfaController extends AbstractController
+{
+    /**
+     * @var MockGateway
+     */
+    private $mockStepupGateway;
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    public function __construct(MockGateway $mockStepupGateway, Environment $twig)
+    {
+        $this->mockStepupGateway = $mockStepupGateway;
+        $this->twig = $twig;
+    }
+
+    /**
+     * This is the sso action used to mock a GSSP callout
+     *
+     * @Route(
+     *     "/mock/sso",
+     *     name="mock_sso"
+     * )
+     *
+     * @param Request $request
+     * @return string|Response
+     */
+    public function ssoAction(Request $request)
+    {
+        if (!in_array($this->getParameter('kernel.environment'), ['test', 'dev'])) {
+            throw new Exception('Invalid environment encountered.');
+        }
+
+        try {
+            // Check binding
+            if (!$request->isMethod(Request::METHOD_GET)) {
+                throw new BadRequestHttpException(sprintf(
+                    'Could not receive AuthnRequest from HTTP Request: expected a GET method, got %s',
+                    $request->getMethod()
+                ));
+            }
+
+            // Parse available responses
+            $responses = $this->getAvailableResponses($request);
+
+            // Present response
+            $body = $this->twig->render(
+                'dev/mock-acs.html.twig',
+                [
+                    'responses' => $responses,
+                ]
+            );
+
+            return new Response($body);
+        } catch (BadRequestHttpException $e) {
+            return new Response($e->getMessage(), $e->getStatusCode());
+        } catch (Exception $e) {
+            return new Response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @param Request $request
+     * @return mixed
+     * @throws Exception
+     */
+    private function getAvailableResponses(Request $request)
+    {
+        // Parse successful
+        $samlResponse = $this->mockStepupGateway->handleSsoSuccess($request, $this->getFullRequestUri($request));
+        $results['success'] = $this->getResponseData($request, $samlResponse);
+
+        // Parse user cancelled
+        $samlResponse = $this->mockStepupGateway->handleSsoFailure(
+            $request,
+            $this->getFullRequestUri($request),
+            Constants::STATUS_RESPONDER,
+            Constants::STATUS_AUTHN_FAILED,
+            'Authentication cancelled by user'
+        );
+        $results['user-cancelled'] = $this->getResponseData($request, $samlResponse);
+
+        // Parse unknown
+        $samlResponse = $this->mockStepupGateway->handleSsoFailure(
+            $request,
+            $this->getFullRequestUri($request),
+            Constants::STATUS_RESPONDER,
+            Constants::STATUS_AUTHN_FAILED
+        );
+        $results['unknown'] = $this->getResponseData($request, $samlResponse);
+
+        return $results;
+    }
+
+    /**
+     * @param Request $request
+     * @param SamlResponse $samlResponse
+     * @return array
+     */
+    private function getResponseData(Request $request, SamlResponse $samlResponse)
+    {
+        $rawResponse = $this->mockStepupGateway->parsePostResponse($samlResponse);
+
+        return [
+            'acu' => $samlResponse->getDestination(),
+            'rawResponse' => $rawResponse,
+            'encodedResponse' => base64_encode($rawResponse),
+            'relayState' => $request->request->get(MockGateway::PARAMETER_RELAY_STATE),
+        ];
+    }
+
+    /**
+     * @param Request $request
+     * @return string
+     */
+    private function getFullRequestUri(Request $request)
+    {
+        return $request->getSchemeAndHttpHost() . $request->getBasePath() . $request->getRequestUri();
+    }
+}

--- a/dev/Controller/SPController.php
+++ b/dev/Controller/SPController.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 /**
  * Copyright 2019 SURFnet B.V.
  *

--- a/dev/Mock/MockConfiguration.php
+++ b/dev/Mock/MockConfiguration.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Dev\Mock;
+
+final class MockConfiguration
+{
+    private $identityProviderEntityId;
+    private $serviceProviderEntityId;
+    private $publicKeyCertData;
+    private $privateKeyPem;
+
+    public function __construct(
+        string $identityProviderEntityId,
+        string $serviceProviderEntityId,
+        string $privateKeyPath,
+        string $publicCertPath
+    ) {
+
+        if (!is_file($privateKeyPath)) {
+            throw new \InvalidArgumentException('Unable to find private key: '. $privateKeyPath);
+        }
+        if (!is_file($publicCertPath)) {
+            throw new \InvalidArgumentException('Unable to find private key: '. $publicCertPath);
+        }
+
+        $this->identityProviderEntityId = $identityProviderEntityId;
+        $this->serviceProviderEntityId = $serviceProviderEntityId;
+        $this->privateKeyPem = file_get_contents($privateKeyPath);
+        $this->publicKeyCertData = file_get_contents($publicCertPath);
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentityProviderEntityId()
+    {
+        return $this->identityProviderEntityId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentityProviderPublicKeyCertData()
+    {
+        return $this->publicKeyCertData;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentityProviderGetPrivateKeyPem()
+    {
+        return $this->privateKeyPem;
+    }
+
+    /**
+     * @return string
+     */
+    public function getServiceProviderEntityId()
+    {
+        return $this->serviceProviderEntityId;
+    }
+
+}

--- a/dev/Mock/MockGateway.php
+++ b/dev/Mock/MockGateway.php
@@ -1,0 +1,428 @@
+<?php declare(strict_types = 1);
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Dev\Mock;
+
+use DateInterval;
+use DateTime;
+use LogicException;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use RuntimeException;
+use SAML2\Assertion;
+use SAML2\AuthnRequest as SAML2AuthnRequest;
+use SAML2\Constants;
+use SAML2\DOMDocumentFactory;
+use SAML2\Message;
+use SAML2\Response;
+use SAML2\XML\saml\SubjectConfirmation;
+use SAML2\XML\saml\SubjectConfirmationData;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class MockGateway
+{
+
+    const PARAMETER_REQUEST = 'SAMLRequest';
+    const PARAMETER_RELAY_STATE = 'RelayState';
+    const PARAMETER_SIGNATURE = 'Signature';
+    const PARAMETER_SIGNATURE_ALGORITHM = 'SigAlg';
+
+    /**
+     * @var DateTime
+     */
+    private $currentTime;
+
+    /**
+     * @var MockConfiguration
+     */
+    private $gatewayConfiguration;
+
+    /**
+     * @param MockConfiguration $gatewayConfiguration
+     * @throws \Exception
+     */
+    public function __construct(
+        MockConfiguration $gatewayConfiguration
+    ) {
+        $this->gatewayConfiguration = $gatewayConfiguration;
+        $this->currentTime = new DateTime();
+    }
+
+    /**
+     * @param Request $request
+     * @param string $fullRequestUri
+     * @return Response
+     */
+    public function handleSsoSuccess(Request $request, $fullRequestUri)
+    {
+        // parse the authnRequest
+        $authnRequest = $this->parseRequest($request, $fullRequestUri);
+
+        // get parameters from authnRequest
+        $nameId = $authnRequest->getNameId()->value;
+        $destination = $authnRequest->getAssertionConsumerServiceURL();
+        $authnContextClassRef = current($authnRequest->getRequestedAuthnContext()['AuthnContextClassRef']);
+        $requestId = $authnRequest->getId();
+
+        // handle success
+        return $this->createSecondFactorOnlyResponse(
+            $nameId,
+            $destination,
+            $authnContextClassRef,
+            $requestId
+        );
+    }
+
+    /**
+     * @param Request $request
+     * @param string $fullRequestUri
+     * @param string $status
+     * @param string $subStatus
+     * @param string $message
+     * @return Response
+     */
+    public function handleSsoFailure(Request $request, $fullRequestUri, $status, $subStatus, $message = '')
+    {
+        // parse the authnRequest
+        $authnRequest = $this->parseRequest($request, $fullRequestUri);
+
+        // get parameters from authnRequest
+        $destination = $authnRequest->getAssertionConsumerServiceURL();
+        $requestId = $authnRequest->getId();
+
+        return $this->createFailureResponse($destination, $requestId, $status, $subStatus, $message);
+    }
+
+
+    /**
+     * @param string $nameId
+     * @param string $destination The ACS location
+     * @param string|null $authnContextClassRef The loa level
+     * @param string $requestId The requestId
+     * @return Response
+     */
+    private function createSecondFactorOnlyResponse($nameId, $destination, $authnContextClassRef, $requestId)
+    {
+        return $this->createNewAuthnResponse(
+            $this->createNewAssertion(
+                $nameId,
+                $authnContextClassRef,
+                $destination,
+                $requestId
+            ),
+            $destination,
+            $requestId
+        );
+    }
+
+    /**
+     * @param string $samlRequest
+     * @param string $fullRequestUri
+     * @return SAML2AuthnRequest
+     * @throws \Exception
+     */
+    private function parseRequest(Request $request, $fullRequestUri)
+    {
+        // the GET parameter is already urldecoded by Symfony, so we should not do it again.
+        $requestData = $request->get(self::PARAMETER_REQUEST);
+
+        if (empty($requestData)){
+            throw new BadRequestHttpException('Missing a request, did not receive a request or request was empty');
+        }
+
+        $samlRequest = base64_decode($requestData, true);
+        if ($samlRequest === false) {
+            throw new BadRequestHttpException('Failed decoding the request, did not receive a valid base64 string');
+        }
+
+        // Catch any errors gzinflate triggers
+        $errorNo = $errorMessage = null;
+        set_error_handler(function ($number, $message) use (&$errorNo, &$errorMessage) {
+            $errorNo      = $number;
+            $errorMessage = $message;
+        });
+        $samlRequest = gzinflate($samlRequest);
+        restore_error_handler();
+
+        if ($samlRequest === false) {
+            throw new BadRequestHttpException(sprintf(
+                'Failed inflating the request; error "%d": "%s"',
+                $errorNo,
+                $errorMessage
+            ));
+        }
+
+        // 1. Parse to xml object
+        // additional security against XXE Processing vulnerability
+        $previous = libxml_disable_entity_loader(true);
+        $document = DOMDocumentFactory::fromString($samlRequest);
+        libxml_disable_entity_loader($previous);
+
+        // 2. Parse saml request
+        $authnRequest = Message::fromXML($document->firstChild);
+
+        if (!$authnRequest instanceof SAML2AuthnRequest) {
+            throw new RuntimeException(sprintf(
+                'The received request is not an AuthnRequest, "%s" received instead',
+                substr(get_class($authnRequest), strrpos($authnRequest, '_') + 1)
+            ));
+        }
+
+        // 3. Validate destination
+        if (!$authnRequest->getDestination() === $fullRequestUri) {
+            throw new BadRequestHttpException(sprintf(
+                'Actual Destination "%s" does not match the AuthnRequest Destination "%s"',
+                $fullRequestUri,
+                $authnRequest->getDestination()
+            ));
+        }
+
+        // 4. Validate issuer
+        if (!$this->gatewayConfiguration->getServiceProviderEntityId() === $authnRequest->getIssuer()) {
+            throw new BadRequestHttpException(sprintf(
+                'Actual issuer "%s" does not match the AuthnRequest Issuer "%s"',
+                $this->gatewayConfiguration->getServiceProviderEntityId(),
+                $authnRequest->getIssuer()
+            ));
+        }
+
+        // 5. Validate key
+        // Note: $authnRequest->validate throws an Exception when the signature does not match.
+        $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, array('type' => 'public'));
+        $key->loadKey($this->gatewayConfiguration->getIdentityProviderPublicKeyCertData());
+
+        // The query string to validate needs to be urlencoded again because Symfony has already decoded this for us
+        $query = self::PARAMETER_REQUEST . '=' . urlencode($requestData);
+        $query .= '&' . self::PARAMETER_SIGNATURE_ALGORITHM . '=' . urlencode($request->get(self::PARAMETER_SIGNATURE_ALGORITHM));
+
+        $signature = base64_decode($request->get(self::PARAMETER_SIGNATURE));
+
+        if (!$key->verifySignature($query, $signature)) {
+            throw new BadRequestHttpException(
+                'Validation of the signature in the AuthnRequest failed'
+            );
+        }
+
+        return $authnRequest;
+    }
+
+    /**
+     * @param Response $response
+     * @return string
+     */
+    public function parsePostResponse(Response $response)
+    {
+        return $response->toUnsignedXML()->ownerDocument->saveXML();
+    }
+
+    /**
+     * @param string $destination The ACS location
+     * @param string $requestId The requestId
+     * @param string $status The response status (see \SAML2\Constants)
+     * @param string|null $subStatus An optional substatus (see \SAML2\Constants)
+     * @param string|null $message The textual message
+     * @return Response
+     */
+    private function createFailureResponse($destination, $requestId, $status, $subStatus = null, $message = null)
+    {
+        $response = new Response();
+        $response->setDestination($destination);
+        $response->setIssuer($this->gatewayConfiguration->getIdentityProviderEntityId());
+        $response->setIssueInstant($this->getTimestamp());
+        $response->setInResponseTo($requestId);
+
+
+        if (!$this->isValidResponseStatus($status)) {
+            throw new LogicException(sprintf('Trying to set invalid Response Status'));
+        }
+
+        if ($subStatus && !$this->isValidResponseSubStatus($subStatus)) {
+            throw new LogicException(sprintf('Trying to set invalid Response SubStatus'));
+        }
+
+        $status = ['Code' => $status];
+        if ($subStatus) {
+            $status['SubCode'] = $subStatus;
+        }
+        if ($message) {
+            $status['Message'] = $message;
+        }
+
+        $response->setStatus($status);
+
+        return $response;
+    }
+
+    /**
+     * @param Assertion $newAssertion
+     * @param string $destination The ACS location
+     * @param string $requestId The requestId
+     * @return Response
+     */
+    private function createNewAuthnResponse(Assertion $newAssertion, $destination, $requestId)
+    {
+        $response = new Response();
+        $response->setAssertions([$newAssertion]);
+        $response->setIssuer($this->gatewayConfiguration->getIdentityProviderEntityId());
+        $response->setIssueInstant($this->getTimestamp());
+        $response->setDestination($destination);
+        $response->setInResponseTo($requestId);
+
+        return $response;
+    }
+
+    /**
+     * @param string $nameId
+     * @param string $authnContextClassRef
+     * @param string $destination The ACS location
+     * @param string $requestId The requestId
+     * @return Assertion
+     */
+    private function createNewAssertion($nameId, $authnContextClassRef, $destination, $requestId)
+    {
+        $newAssertion = new Assertion();
+        $newAssertion->setNotBefore($this->currentTime->getTimestamp());
+        $newAssertion->setNotOnOrAfter($this->getTimestamp('PT5M'));
+        $newAssertion->setIssuer($this->gatewayConfiguration->getIdentityProviderEntityId());
+        $newAssertion->setIssueInstant($this->getTimestamp());
+        $this->signAssertion($newAssertion);
+        $this->addSubjectConfirmationFor($newAssertion, $destination, $requestId);
+        $newAssertion->setNameId([
+            'Format' => Constants::NAMEID_UNSPECIFIED,
+            'Value' => $nameId,
+        ]);
+        $newAssertion->setValidAudiences([$this->gatewayConfiguration->getServiceProviderEntityId()]);
+        $this->addAuthenticationStatementTo($newAssertion, $authnContextClassRef);
+
+        return $newAssertion;
+    }
+
+    /**
+     * @param Assertion $newAssertion
+     * @param string $destination The ACS location
+     * @param string $requestId The requestId
+     */
+    private function addSubjectConfirmationFor(Assertion $newAssertion, $destination, $requestId)
+    {
+        $confirmation         = new SubjectConfirmation();
+        $confirmation->Method = Constants::CM_BEARER;
+
+        $confirmationData                      = new SubjectConfirmationData();
+        $confirmationData->InResponseTo        = $requestId;
+        $confirmationData->Recipient           = $destination;
+        $confirmationData->NotOnOrAfter        = $newAssertion->getNotOnOrAfter();
+
+        $confirmation->SubjectConfirmationData = $confirmationData;
+
+        $newAssertion->setSubjectConfirmation([$confirmation]);
+    }
+
+    /**
+     * @param Assertion $assertion
+     * @param $authnContextClassRef
+     */
+    private function addAuthenticationStatementTo(Assertion $assertion, $authnContextClassRef)
+    {
+        $assertion->setAuthnInstant($this->getTimestamp());
+        $assertion->setAuthnContextClassRef($authnContextClassRef);
+        $assertion->setAuthenticatingAuthority([$this->gatewayConfiguration->getIdentityProviderEntityId()]);
+    }
+
+    /**
+     * @param string $interval a DateInterval compatible interval to skew the time with
+     * @return int
+     */
+    private function getTimestamp($interval = null)
+    {
+        $time = clone $this->currentTime;
+
+        if ($interval) {
+            $time->add(new DateInterval($interval));
+        }
+
+        return $time->getTimestamp();
+    }
+
+    /**
+     * @param Assertion $assertion
+     * @return Assertion
+     */
+    private function signAssertion(Assertion $assertion)
+    {
+        $assertion->setSignatureKey($this->loadPrivateKey());
+        $assertion->setCertificates([$this->getPublicCertificate()]);
+
+        return $assertion;
+    }
+
+    /**
+     * @return XMLSecurityKey
+     */
+    private function loadPrivateKey()
+    {
+        $xmlSecurityKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, ['type' => 'private']);
+        $xmlSecurityKey->loadKey($this->gatewayConfiguration->getIdentityProviderGetPrivateKeyPem());
+
+        return $xmlSecurityKey;
+    }
+
+    /**
+     * @return string
+     */
+    private function getPublicCertificate()
+    {
+        return $this->gatewayConfiguration->getIdentityProviderPublicKeyCertData();
+    }
+
+    private function isValidResponseStatus($status)
+    {
+        return in_array($status, [
+            Constants::STATUS_SUCCESS,            // weeee!
+            Constants::STATUS_REQUESTER,          // Something is wrong with the AuthnRequest
+            Constants::STATUS_RESPONDER,          // Something went wrong with the Response
+            Constants::STATUS_VERSION_MISMATCH,   // The version of the request message was incorrect
+        ]);
+    }
+
+    private function isValidResponseSubStatus($subStatus)
+    {
+        return in_array($subStatus, [
+            Constants::STATUS_AUTHN_FAILED,               // failed authentication
+            Constants::STATUS_INVALID_ATTR,
+            Constants::STATUS_INVALID_NAMEID_POLICY,
+            Constants::STATUS_NO_AUTHN_CONTEXT,           // insufficient Loa or Loa cannot be met
+            Constants::STATUS_NO_AVAILABLE_IDP,
+            Constants::STATUS_NO_PASSIVE,
+            Constants::STATUS_NO_SUPPORTED_IDP,
+            Constants::STATUS_PARTIAL_LOGOUT,
+            Constants::STATUS_PROXY_COUNT_EXCEEDED,
+            Constants::STATUS_REQUEST_DENIED,
+            Constants::STATUS_REQUEST_UNSUPPORTED,
+            Constants::STATUS_REQUEST_VERSION_DEPRECATED,
+            Constants::STATUS_REQUEST_VERSION_TOO_HIGH,
+            Constants::STATUS_REQUEST_VERSION_TOO_LOW,
+            Constants::STATUS_RESOURCE_NOT_RECOGNIZED,
+            Constants::STATUS_TOO_MANY_RESPONSES,
+            Constants::STATUS_UNKNOWN_ATTR_PROFILE,
+            Constants::STATUS_UNKNOWN_PRINCIPAL,
+            Constants::STATUS_UNSUPPORTED_BINDING,
+        ]);
+    }
+}

--- a/homestead/php.ini
+++ b/homestead/php.ini
@@ -1,4 +1,0 @@
-xdebug.remote_autostart = 1
-xdebug.remote_host = 192.168.77.2
-xdebug.remote_connect_back = 0
-xdebug.coverage_enable=1

--- a/templates/dev/mock-acs.html.twig
+++ b/templates/dev/mock-acs.html.twig
@@ -1,0 +1,20 @@
+<html>
+    <noscript>
+        <b>Note: </b> javascript is disabled, please click the button below to proceed
+    </noscript>
+    One moment please...
+
+    {% for id, response in responses %}
+        <h2>{{ id }}</h2>
+        <form method="post" action="{{ response.acu }}">
+            <input type="hidden" name="SAMLResponse" value="{{ response.encodedResponse }}" />
+        {% if response.relayState|length > 0 %}
+            <input type="hidden" name="RelayState" value="{{ response.relayState|escape }}" />
+        {% endif %}
+            <input type="submit" class="hidden" />
+        <noscript>
+            <input type="submit" value="Submit-{{ id }}"/>
+        </noscript>
+        </form>
+    {% endfor %}
+</html>

--- a/tests/Functional/WebTests/MockAzureMfaControllerTest.php
+++ b/tests/Functional/WebTests/MockAzureMfaControllerTest.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\AzureMfa\Test\Functional\WebTests;
+
+use Exception;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use SAML2\Certificate\PrivateKeyLoader;
+use SAML2\Configuration\PrivateKey;
+use Surfnet\SamlBundle\Entity\IdentityProvider;
+use Surfnet\SamlBundle\Entity\ServiceProvider;
+use Surfnet\SamlBundle\SAML2\AuthnRequest;
+use Surfnet\SamlBundle\SAML2\AuthnRequestFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class MockAzureMfaControllerTest extends WebTestCase
+{
+    /**
+     * @var \Symfony\Bundle\FrameworkBundle\KernelBrowser
+     */
+    private $client;
+    /**
+     * @var string
+     */
+    private $publicKey;
+    /**
+     * @var string
+     */
+    private $privateKey;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();;
+        $projectDir = self::$kernel->getProjectDir();
+
+        $this->publicKey = $projectDir . '/vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_publickey.cer';
+        $this->privateKey = $projectDir . '/vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_privatekey.pem';
+    }
+
+    public function testDecisionPage()
+    {
+        $emailAddress = 'user@organization.tld';
+
+        $authnRequestUrl = $this->createAuthnRequestUrl($this->createServiceProvider(), $this->createIdentityProvider(), $emailAddress);
+
+        $crawler = $this->client->request('GET', $authnRequestUrl);
+
+        // Test if on decision page
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('success', $crawler->filter('h2')->text());
+        $this->assertStringContainsString('One moment please...', $this->client->getResponse()->getContent());
+    }
+
+    public function testSuccessfulResponse()
+    {
+        $emailAddress = 'user@organization.tld';
+
+        $authnRequestUrl = $this->createAuthnRequestUrl($this->createServiceProvider(), $this->createIdentityProvider(), $emailAddress);
+
+        $crawler = $this->client->request('GET', $authnRequestUrl);
+
+        // Test if on decision page
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('success', $crawler->filter('h2')->text());
+
+        // Return success response
+        $form = $crawler->selectButton('Submit-success')->form();
+        $crawler = $this->client->submit($form);
+
+        // Test if on sp acs
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('Demo Service provider ConsumerAssertionService endpoint', $crawler->filter('h2')->text());
+        $this->assertStringContainsString($emailAddress, $this->client->getResponse());
+    }
+
+    public function testUserCancelledResponse()
+    {
+        $emailAddress = 'user@organization.tld';
+
+        $authnRequestUrl = $this->createAuthnRequestUrl($this->createServiceProvider(), $this->createIdentityProvider(), $emailAddress);
+
+        $crawler = $this->client->request('GET', $authnRequestUrl);
+
+        // Test if on decision page
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('success', $crawler->filter('h2')->text());
+
+        // Return success response
+        $form = $crawler->selectButton('Submit-user-cancelled')->form();
+        $crawler = $this->client->submit($form);
+
+        // Test if on sp acs
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('Demo Service provider ConsumerAssertionService endpoint', $crawler->filter('h2')->text());
+        $this->assertStringContainsString('Error SAMLResponse', $this->client->getResponse());
+        $this->assertStringContainsString('Responder/AuthnFailed Authentication cancelled by user', $this->client->getResponse());
+    }
+
+    public function testUnsuccessfulResponse()
+    {
+        $emailAddress = 'user@organization.tld';
+
+        $authnRequestUrl = $this->createAuthnRequestUrl($this->createServiceProvider(), $this->createIdentityProvider(), $emailAddress);
+
+        $crawler = $this->client->request('GET', $authnRequestUrl);
+
+        // Test if on decision page
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('success', $crawler->filter('h2')->text());
+
+        // Return success response
+        $form = $crawler->selectButton('Submit-unknown')->form();
+        $crawler = $this->client->submit($form);
+
+        // Test if on sp acs
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('Demo Service provider ConsumerAssertionService endpoint', $crawler->filter('h2')->text());
+        $this->assertStringContainsString('Error SAMLResponse', $this->client->getResponse());
+        $this->assertStringContainsString('Responder/AuthnFailed', $this->client->getResponse());
+    }
+
+    /**
+     * @param ServiceProvider $serviceProvider
+     * @param IdentityProvider $identityProvider
+     * @param string $url
+     * @param string $emailAddress
+     * @return string
+     */
+    private function createAuthnRequestUrl(ServiceProvider $serviceProvider, IdentityProvider $identityProvider, string $emailAddress)
+    {
+        $authnRequest = AuthnRequestFactory::createNewRequest($serviceProvider, $identityProvider);
+
+        // Set subject tyo UPN (user email address)
+        $authnRequest->setSubject($emailAddress);
+
+        // Set authnContextClassRef to force MFA
+        $authnRequest->setAuthenticationContextClassRef('http://schemas.microsoft.com/claims/multipleauthn');
+
+        // Build request query parameters.
+        $requestAsXml = $authnRequest->getUnsignedXML();
+        $encodedRequest = base64_encode(gzdeflate($requestAsXml));
+        $queryParams = [AuthnRequest::PARAMETER_REQUEST => $encodedRequest];
+
+        // Create redirect response.
+        $query = $this->signRequestQuery($queryParams, $serviceProvider);
+        return sprintf('%s?%s', $identityProvider->getSsoUrl(), $query);
+    }
+
+    private function createServiceProvider(): ServiceProvider
+    {
+        $samlBundle = '';
+        return new ServiceProvider(
+            [
+                'entityId' => 'https://azure-mfa.stepup.example.com/saml/metadata',
+                'assertionConsumerUrl' => 'https://azure-mfa.stepup.example.com/demo/sp/acs',
+                'certificateFile' => $this->publicKey,
+                'privateKeys' => [
+                    new PrivateKey(
+                        $this->privateKey,
+                        'default'
+                    ),
+                ],
+                'sharedKey' => sprintf('%s/src/Resources/keys/development_publickey.cer', $samlBundle),
+            ]
+        );
+    }
+
+    private function createIdentityProvider(): IdentityProvider
+    {
+        $samlBundle = '';
+        return new IdentityProvider(
+            [
+                'entityId' => 'https://azure-mfa.stepup.example.com/mock/idp/metadata',
+                'ssoUrl' => 'https://azure-mfa.stepup.example.com/mock/sso',
+                'certificateFile' => $this->publicKey,
+                'privateKeys' => [
+                    new PrivateKey(
+                        $this->privateKey,
+                        'default'
+                    ),
+                ],
+                'sharedKey' => sprintf('%s/src/Resources/keys/development_publickey.cer', $samlBundle),
+            ]
+        );
+    }
+
+    /**
+     * Sign AuthnRequest query parameters.
+     *
+     * @param array $queryParams
+     * @param ServiceProvider $serviceProvider
+     * @return string
+     *
+     * @throws Exception
+     */
+    private function signRequestQuery(array $queryParams, ServiceProvider $serviceProvider)
+    {
+        /** @var  $securityKey */
+        $securityKey = $this->loadServiceProviderPrivateKey($serviceProvider);
+        $queryParams[AuthnRequest::PARAMETER_SIGNATURE_ALGORITHM] = $securityKey->type;
+        $toSign = http_build_query($queryParams);
+        $signature = $securityKey->signData($toSign);
+
+        return $toSign . '&Signature=' . urlencode(base64_encode($signature));
+    }
+
+    /**
+     * Loads the private key from the service provider.
+     *
+     * @param ServiceProvider $serviceProvider
+     * @return XMLSecurityKey
+     *
+     * @throws Exception
+     */
+    private function loadServiceProviderPrivateKey(ServiceProvider $serviceProvider)
+    {
+        $keyLoader = new PrivateKeyLoader();
+        $privateKey = $keyLoader->loadPrivateKey(
+            $serviceProvider->getPrivateKey(PrivateKey::NAME_DEFAULT)
+        );
+        $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, ['type' => 'private']);
+        $key->loadKey($privateKey->getKeyAsString());
+
+        return $key;
+    }
+}

--- a/tests/Unit/Domain/Institution/ValueObject/EmailDomainWildcardTest.php
+++ b/tests/Unit/Domain/Institution/ValueObject/EmailDomainWildcardTest.php
@@ -76,6 +76,7 @@ class EmailDomainWildcardTest extends TestCase
     {
         return [
             ['*.example.com', 'stybar@stepup.example.com'],
+            ['*.example.com', 'stybar@stepup.example.com'],
             ['*.example.com', 'stybar@openconext.example.com'],
             ['*.example.com', 'stybar@openconext.stepup.example.com'],
             ['*.example.com', 'StYbAr@sTepUp.eXaMpLe.cOm'],


### PR DESCRIPTION
A mock SSO endpoint is created to be able to test the expected
responses from MFA. This is an initial setup according to the
requirements given but probably will need some TLC to get better
real life results.