### PR TITLE
Move controller validation logic to constraint

### DIFF
--- a/src/Surfnet/AzureMfa/Infrastructure/Form/EmailAddressDto.php
+++ b/src/Surfnet/AzureMfa/Infrastructure/Form/EmailAddressDto.php
@@ -21,11 +21,12 @@ namespace Surfnet\AzureMfa\Infrastructure\Form;
 use Surfnet\AzureMfa\Domain\EmailAddress;
 use Symfony\Component\Validator\Constraints as Assert;
 
-final class EmailAddressModel
+final class EmailAddressDto
 {
     /**
      * @Assert\NotBlank
      * @Assert\Email
+     * @Surfnet\AzureMfa\Infrastructure\Validator\Constraint\EmailDomainInConfiguration
      */
     private $emailAddress = '';
 

--- a/src/Surfnet/AzureMfa/Infrastructure/Form/EmailAddressType.php
+++ b/src/Surfnet/AzureMfa/Infrastructure/Form/EmailAddressType.php
@@ -36,6 +36,6 @@ final class EmailAddressType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefault('data_class', EmailAddressModel::class);
+        $resolver->setDefault('data_class', EmailAddressDto::class);
     }
 }

--- a/src/Surfnet/AzureMfa/Infrastructure/Validator/Constraint/EmailDomainInConfiguration.php
+++ b/src/Surfnet/AzureMfa/Infrastructure/Validator/Constraint/EmailDomainInConfiguration.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\AzureMfa\Infrastructure\Validator\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class EmailDomainInConfiguration extends Constraint
+{
+    public $message = 'The provided email address did not match any of our configured email domains.';
+
+    public function validatedBy()
+    {
+        return EmailDomainInConfigurationValidator::class;
+    }
+}

--- a/src/Surfnet/AzureMfa/Infrastructure/Validator/Constraint/EmailDomainInConfigurationValidator.php
+++ b/src/Surfnet/AzureMfa/Infrastructure/Validator/Constraint/EmailDomainInConfigurationValidator.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\AzureMfa\Infrastructure\Validator\Constraint;
+
+use Surfnet\AzureMfa\Application\Institution\Service\EmailDomainMatchingService;
+use Surfnet\AzureMfa\Domain\EmailAddress;
+use Surfnet\AzureMfa\Domain\Exception\InvalidEmailAddressException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class EmailDomainInConfigurationValidator extends ConstraintValidator
+{
+    /**
+     * @var EmailDomainMatchingService
+     */
+    private $matchingService;
+
+    public function __construct(EmailDomainMatchingService $service)
+    {
+        $this->matchingService = $service;
+    }
+
+    /**
+     * @param mixed $value
+     * @param Constraint $constraint
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof EmailDomainInConfiguration) {
+            throw new UnexpectedTypeException($constraint, EmailDomainInConfiguration::class);
+        }
+
+        // custom constraints should ignore null and empty values to allow
+        // other constraints (NotBlank, NotNull, etc.) take care of that
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        try {
+            $email = new EmailAddress($value);
+        } catch (InvalidEmailAddressException $e) {
+            throw new UnexpectedTypeException($constraint, EmailDomainInConfiguration::class);
+        }
+
+        if (is_null($this->matchingService->findInstitutionByEmail($email))) {
+            $this->context->buildViolation($constraint->message)
+                ->addViolation();
+        }
+    }
+}

--- a/src/Surfnet/AzureMfa/Infrastructure/Validator/Constraint/EmailDomainInConfigurationValidator.php
+++ b/src/Surfnet/AzureMfa/Infrastructure/Validator/Constraint/EmailDomainInConfigurationValidator.php
@@ -63,5 +63,7 @@ class EmailDomainInConfigurationValidator extends ConstraintValidator
             $this->context->buildViolation($constraint->message)
                 ->addViolation();
         }
+
+        return;
     }
 }

--- a/templates/default/registration.html.twig
+++ b/templates/default/registration.html.twig
@@ -13,8 +13,5 @@
         </div>
     {% endif %}
 
-    {% if customErrorMessage is not null %}
-        {{ customErrorMessage }}
-    {% endif %}
     {{ form(form) }}
 {% endblock %}

--- a/tests/Functional/Features/registration.feature
+++ b/tests/Functional/Features/registration.feature
@@ -12,10 +12,11 @@ Feature: When an user needs to register for a new token
     Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
 
   Scenario: Registration fails when an invalid email address is provided by the user
-    Given I send a registration request request to "https://azure-mfa.stepup.example.com/registration"
+    Given I send a registration request request to "https://azure-mfa.stepup.example.com/saml/sso"
     # Fill an email address that does not match any of the configured email domains
     Then I should see "Registration"
-    And I fill in "Email address" with "test-user@institution-x.example.com"
+    And I fill in "Email address" with "test-user@institution-xample.com"
+    When I press "Submit"
     When I press "Submit"
     Then I should be on "https://azure-mfa.stepup.example.com/registration"
     And I should see "The provided email address did not match any of our configured email domains."

--- a/tests/Unit/Infrastructure/Validator/Constraint/EmailDomainInConfigurationValidatorTest.php
+++ b/tests/Unit/Infrastructure/Validator/Constraint/EmailDomainInConfigurationValidatorTest.php
@@ -1,0 +1,96 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\AzureMfa\Infrastructure\Validator\Constraint;
+
+use Generator;
+use Mockery as m;
+use Mockery\Mock;
+use PHPUnit\Framework\TestCase;
+use Surfnet\AzureMfa\Application\Institution\Service\EmailDomainMatchingService;
+use Surfnet\AzureMfa\Domain\Institution\ValueObject\Institution;
+use Symfony\Component\Validator\Constraints\Isbn;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class EmailDomainInConfigurationValidatorTest extends TestCase
+{
+    /**
+     * @var EmailDomainInConfigurationValidator
+     */
+    private $validator;
+
+    /**
+     * @var EmailDomainMatchingService&Mock
+     */
+    private $service;
+
+    /**
+     * @var m\MockInterface&ExecutionContextInterface
+     */
+    private $context;
+
+    protected function setUp(): void
+    {
+        $this->service = m::mock(EmailDomainMatchingService::class);
+        $this->validator = new EmailDomainInConfigurationValidator($this->service);
+        $this->context = m::mock(ExecutionContextInterface::class);
+        $this->validator->initialize($this->context);
+    }
+
+    public function test_happy_flow(): void
+    {
+        $this->service
+            ->shouldReceive('findInstitutionByEmail')
+            ->andReturn(m::mock(Institution::class));
+        $this->assertNull($this->validator->validate('foobar@example.com', new EmailDomainInConfiguration()));
+    }
+
+    public function test_validate_empty_address(): void
+    {
+        $this->service
+            ->shouldReceive('findInstitutionByEmail')
+            ->andReturn(m::mock(Institution::class));
+        $this->assertNull($this->validator->validate('', new EmailDomainInConfiguration()));
+    }
+
+    public function test_validate_domain_not_matched_to_institution(): void
+    {
+        $this->service
+            ->shouldReceive('findInstitutionByEmail')
+            ->andReturn(null);
+        $this->context
+            ->shouldReceive('buildViolation->addViolation');
+        $this->assertNull($this->validator->validate('foobar@stepup.example.com', new EmailDomainInConfiguration()));
+    }
+
+    /**
+     * @dataProvider provideInvalidInput
+     */
+    public function test_invalid_input($invalidValue, $constraint): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->validator->validate($invalidValue, $constraint);
+    }
+
+    public function provideInvalidInput(): Generator
+    {
+        yield ['foobar@inval$d', new EmailDomainInConfiguration()];
+        yield ['foobar@example.com', new Isbn()];
+    }
+}


### PR DESCRIPTION
The EmailDomainInConfiguration constraint now verifies if the provided email address matches any of the configured email domains.