### PR TITLE
Use mock mfa client as ADFS for development

### DIFF
--- a/src/Surfnet/AzureMfa/Application/Service/AzureMfaService.php
+++ b/src/Surfnet/AzureMfa/Application/Service/AzureMfaService.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\AzureMfa\Application\Service;
+
+use Exception;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use SAML2\Assertion;
+use SAML2\Certificate\PrivateKeyLoader;
+use SAML2\Configuration\PrivateKey;
+use Surfnet\SamlBundle\Entity\IdentityProvider;
+use Surfnet\SamlBundle\Entity\ServiceProvider;
+use Surfnet\SamlBundle\Http\PostBinding;
+use Surfnet\SamlBundle\SAML2\AuthnRequest;
+use Surfnet\SamlBundle\SAML2\AuthnRequestFactory;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class AzureMfaService
+{
+
+    /**
+     * @var string
+     */
+    private $publicKey;
+    /**
+     * @var string
+     */
+    private $privateKey;
+    /**
+     * @var PostBinding
+     */
+    private $postBinding;
+
+    public function __construct(
+        PostBinding $postBinding
+    ) {
+        $this->postBinding = $postBinding;
+
+        // Todo: make keys configurable
+        $this->publicKey = __DIR__ . '/../../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_publickey.cer';
+        $this->privateKey = __DIR__ . '/../../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_privatekey.pem';
+    }
+
+    /**
+     * @param string $nameId
+     * @return RedirectResponse
+     * @throws Exception
+     */
+    public function createAuthnRequest(string $nameId): string
+    {
+        $authnRequest = AuthnRequestFactory::createNewRequest($this->getServiceProvider(), $this->getIdentityProvider());
+
+        // Use emailaddress as subject
+        $authnRequest->setSubject($nameId);
+
+        // Set authnContextClassRef to force MFA
+        $authnRequest->setAuthenticationContextClassRef('http://schemas.microsoft.com/claims/multipleauthn');
+
+        // Create redirect response.
+        $query = $authnRequest->buildRequestQuery();
+        return sprintf('%s?%s', $this->getIdentityProvider()->getSsoUrl(), $query);
+    }
+
+    /**
+     * @param Request $request
+     */
+    public function handleResponse(Request $request)
+    {
+        /** @var Assertion $response */
+        $this->postBinding->processResponse($request, $this->getIdentityProvider(), $this->getServiceProvider());
+
+        //TODO: do we need additional validation?
+    }
+
+    private function getServiceProvider(): ServiceProvider
+    {
+        // TODO: make configurable
+        return new ServiceProvider(
+            [
+                'entityId' => 'https://azure-mfa.stepup.example.com/saml/metadata',
+                'assertionConsumerUrl' => 'https://azure-mfa.stepup.example.com/acs',
+                'certificateFile' => $this->publicKey,
+                'privateKeys' => [
+                    new PrivateKey(
+                        $this->privateKey,
+                        'default'
+                    ),
+                ],
+            ]
+        );
+    }
+
+    private function getIdentityProvider(): IdentityProvider
+    {
+        // TODO: make configurable
+        return new IdentityProvider(
+            [
+                'entityId' => 'https://azure-mfa.stepup.example.com/mock/idp/metadata',
+                'ssoUrl' => 'https://azure-mfa.stepup.example.com/mock/sso',
+                'certificateFile' => $this->publicKey,
+                'privateKeys' => [
+                    new PrivateKey(
+                        $this->privateKey,
+                        'default'
+                    ),
+                ],
+            ]
+        );
+    }
+}

--- a/src/Surfnet/AzureMfa/Infrastructure/Controller/DefaultController.php
+++ b/src/Surfnet/AzureMfa/Infrastructure/Controller/DefaultController.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 /**
  * Copyright 2019 SURFnet B.V.
@@ -18,12 +18,24 @@
 
 namespace Surfnet\AzureMfa\Infrastructure\Controller;
 
+use Exception;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use SAML2\Assertion;
+use SAML2\Certificate\PrivateKeyLoader;
+use SAML2\Configuration\PrivateKey;
 use Surfnet\AzureMfa\Application\Institution\Service\EmailDomainMatchingService;
 use Surfnet\AzureMfa\Infrastructure\Form\EmailAddressDto;
 use Surfnet\AzureMfa\Infrastructure\Form\EmailAddressType;
 use Surfnet\GsspBundle\Service\AuthenticationService;
 use Surfnet\GsspBundle\Service\RegistrationService;
+use Surfnet\SamlBundle\Entity\IdentityProvider;
+use Surfnet\SamlBundle\Entity\ServiceProvider;
+use Surfnet\SamlBundle\Http\Exception\AuthnFailedSamlResponseException;
+use Surfnet\SamlBundle\Http\PostBinding;
+use Surfnet\SamlBundle\SAML2\AuthnRequest;
+use Surfnet\SamlBundle\SAML2\AuthnRequestFactory;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -33,15 +45,34 @@ class DefaultController extends AbstractController
     private $authenticationService;
     private $registrationService;
     private $domainMatchingService;
+    /**
+     * @var PostBinding
+     */
+    private $postBinding;
+    /**
+     * @var string
+     */
+    private $publicKey;
+    /**
+     * @var string
+     */
+    private $privateKey;
 
     public function __construct(
         AuthenticationService $authenticationService,
         RegistrationService $registrationService,
-        EmailDomainMatchingService $domainMatchingService
-    ) {
+        EmailDomainMatchingService $domainMatchingService,
+        PostBinding $postBinding
+    )
+    {
         $this->authenticationService = $authenticationService;
         $this->registrationService = $registrationService;
         $this->domainMatchingService = $domainMatchingService;
+        $this->postBinding = $postBinding;
+
+        // Todo: make keys configurable
+        $this->publicKey = __DIR__ . '/../../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_publickey.cer';
+        $this->privateKey = __DIR__ . '/../../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_privatekey.pem';
     }
 
     /**
@@ -77,7 +108,8 @@ class DefaultController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $this->registrationService->register($emailAddress->getEmailAddress());
-            return $this->registrationService->replyToServiceProvider();
+
+            return $this->handleAuthnRequestToAdfs($emailAddress->getEmailAddress(), $this->createServiceProvider(), $this->createIdentityProvider());
         }
 
         return $this->render('default/registration.html.twig', [
@@ -105,7 +137,8 @@ class DefaultController extends AbstractController
         if ($request->get('action') === 'authenticate') {
             // The application should very if the user matches the nameId.
             $this->authenticationService->authenticate();
-            return $this->authenticationService->replyToServiceProvider();
+
+            return $this->handleAuthnRequestToAdfs($nameId, $this->createServiceProvider(), $this->createIdentityProvider());
         }
 
         $requiresAuthentication = $this->authenticationService->authenticationRequired();
@@ -116,4 +149,139 @@ class DefaultController extends AbstractController
             'NameID' => $nameId ?: 'unknown',
         ], $response);
     }
+
+    /**
+     * @Route("/acs", name="app_identity_acs")
+     */
+    public function acsAction(Request $request)
+    {
+
+        $xmlResponse = $request->request->get('SAMLResponse');
+        $xml = base64_decode($xmlResponse);
+        try {
+            /** @var Assertion $response */
+            $response = $this->postBinding->processResponse($request, $this->createIdentityProvider(), $this->createServiceProvider());
+
+            //TODO: do we need additional validation?
+
+        } catch (AuthnFailedSamlResponseException $e) {
+            $this->registrationService->reject($request->get('message'));
+        } catch (\Exception $e) {
+            $this->registrationService->reject($request->get('message'));
+        }
+
+        return $this->registrationService->replyToServiceProvider();
+    }
+
+    /**
+     * @param string $nameId
+     * @param ServiceProvider $serviceProvider
+     * @param IdentityProvider $identityProvider
+     * @return RedirectResponse
+     * @throws Exception
+     */
+    private function handleAuthnRequestToAdfs(string $nameId, ServiceProvider $serviceProvider, IdentityProvider $identityProvider)
+    {
+        $authnRequest = AuthnRequestFactory::createNewRequest($serviceProvider, $identityProvider);
+
+        // Use emailaddress as subject
+        $authnRequest->setSubject($nameId);
+
+        // Set authnContextClassRef to force MFA
+        $authnRequest->setAuthenticationContextClassRef('http://schemas.microsoft.com/claims/multipleauthn');
+
+        // Build request query parameters.
+        $requestAsXml = $authnRequest->getUnsignedXML();
+        $encodedRequest = base64_encode(gzdeflate($requestAsXml));
+        $queryParams = [AuthnRequest::PARAMETER_REQUEST => $encodedRequest];
+
+        // Create redirect response.
+        $query = $this->signRequestQuery($queryParams);
+        $url = sprintf('%s?%s', $identityProvider->getSsoUrl(), $query);
+
+        return new RedirectResponse($url);
+    }
+
+    /**
+     * Sign AuthnRequest query parameters.
+     *
+     * @param array $queryParams
+     * @return string
+     *
+     * @throws Exception
+     */
+    private function signRequestQuery(array $queryParams)
+    {
+        /** @var  $securityKey */
+        $securityKey = $this->loadServiceProviderPrivateKey();
+        $queryParams[AuthnRequest::PARAMETER_SIGNATURE_ALGORITHM] = $securityKey->type;
+        $toSign = http_build_query($queryParams);
+        $signature = $securityKey->signData($toSign);
+
+        return $toSign . '&Signature=' . urlencode(base64_encode($signature));
+    }
+
+    /**
+     * Loads the private key from the service provider.
+     *
+     * @return XMLSecurityKey
+     *
+     * @throws Exception
+     */
+    private function loadServiceProviderPrivateKey()
+    {
+        $keyLoader = new PrivateKeyLoader();
+        $privateKey = $keyLoader->loadPrivateKey(
+            new PrivateKey(
+                $this->privateKey,
+                'default'
+            )
+        );
+        $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, ['type' => 'private']);
+        $key->loadKey($privateKey->getKeyAsString());
+
+        return $key;
+    }
+
+
+    private function createServiceProvider(): ServiceProvider
+    {
+        // TODO: make configurable
+        $samlBundle = '';
+        return new ServiceProvider(
+            [
+                'entityId' => 'https://azure-mfa.stepup.example.com/saml/metadata',
+                'assertionConsumerUrl' => 'https://azure-mfa.stepup.example.com/acs',
+                'certificateFile' => $this->publicKey,
+                'privateKeys' => [
+                    new PrivateKey(
+                        $this->privateKey,
+                        'default'
+                    ),
+                ],
+                'sharedKey' => sprintf('%s/src/Resources/keys/development_publickey.cer', $samlBundle),
+            ]
+        );
+    }
+
+    private function createIdentityProvider(): IdentityProvider
+    {
+        // TODO: make configurable
+        $samlBundle = '';
+        return new IdentityProvider(
+            [
+                'entityId' => 'https://azure-mfa.stepup.example.com/mock/idp/metadata',
+                'ssoUrl' => 'https://azure-mfa.stepup.example.com/mock/sso',
+                'certificateFile' => $this->publicKey,
+                'privateKeys' => [
+                    new PrivateKey(
+                        $this->privateKey,
+                        'default'
+                    ),
+                ],
+                'sharedKey' => sprintf('%s/src/Resources/keys/development_publickey.cer', $samlBundle),
+            ]
+        );
+    }
+
 }


### PR DESCRIPTION
This is a MVP to implement the MFA mock client into the development
environment to be able to develop the Azure MFA GSSP.

Some TLC is still needed:
- [x] Create separate dedicated ADFS/MFA service
- [ ] Add basic test coverage, or is current sufficient?
- [ ] Check if we need more in depth SAML validation when returning from ADFS
- [ ] Make MFA SP and IDP configurable
- [ ] Discuss overall configuration