### PR TITLE
Remove php_errors.log property

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -12,8 +12,6 @@ framework:
     assets: ~
     #esi: true
     fragments: true
-    php_errors:
-        log: false
     templating:
         engines:
             - twig

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -14,7 +14,3 @@ monolog:
         console:
             type: console
             process_psr_3_messages: false
-
-framework:
-    php_errors:
-        log: false # change error reporting level to: E_ALL & ~E_DEPRECATED (32767 - 8192 = 24575)


### PR DESCRIPTION
The default '%kernel.debug%' seems to be the exact setting we are
looking for. Silencing the logs for prod, and having a nice and verbose
dev log.