### PR TITLE
Disable SameSite setting for session cookies

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -8,7 +8,9 @@ framework:
     session:
         handler_id: null
         cookie_secure: auto
-        cookie_samesite: lax
+        # SameSite is set to none. As we must allow receiving a session cookie from the (trusted)
+        # remote Azure MFA IdP's
+        cookie_samesite: 'none'
     assets: ~
     #esi: true
     fragments: true


### PR DESCRIPTION
The PHP session cookie should not have the samesite lax or strict setting. As this would prevent the session cookie from being present when the remote Azure MFA IdP sends back a SAML response.

So it is set to the for now advisable 'none' setting. Combined with the secure setting, this will be accepted by modern browsers.

**See:**
https://www.pivotaltracker.com/story/show/171721565
symfony/symfony#31475