### PR TITLE
Read original issuer from Scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1
+ - ForceAuthn feature introduced in #21 was changed to peek into the scoping requester ids for retrieving the issuing SP. #24
+ - Installed JS security upgrades #25 
+
 # 1.1.0
  - Session cookies are setup with SameSite=None #22
  - JS dependencies have been updated #23

--- a/composer.lock
+++ b/composer.lock
@@ -929,16 +929,16 @@
         },
         {
             "name": "surfnet/stepup-gssp-bundle",
-            "version": "3.0.5",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-gssp-bundle.git",
-                "reference": "941d9a7ed5fe680a7cc7d4bea9a8c3e411da7633"
+                "reference": "5db1042fbda8cc164e364164f72ca6260fbcb39b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-gssp-bundle/zipball/941d9a7ed5fe680a7cc7d4bea9a8c3e411da7633",
-                "reference": "941d9a7ed5fe680a7cc7d4bea9a8c3e411da7633",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-gssp-bundle/zipball/5db1042fbda8cc164e364164f72ca6260fbcb39b",
+                "reference": "5db1042fbda8cc164e364164f72ca6260fbcb39b",
                 "shasum": ""
             },
             "require": {
@@ -974,20 +974,20 @@
                 "Apache-2.0"
             ],
             "description": "A Symfony 3 bundle (with SF 4 support) to aid the creation of GSSP (Generic SAML Step-up Provider) device support.",
-            "time": "2020-02-24T09:27:27+00:00"
+            "time": "2020-03-19T09:54:38+00:00"
         },
         {
             "name": "surfnet/stepup-saml-bundle",
-            "version": "4.1.10",
+            "version": "4.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-saml-bundle.git",
-                "reference": "756310e6628b6dc9cfe66c81e37494fb470bc3bf"
+                "reference": "2fa2d44e5a005c2044b7898d9624648a4850b129"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-saml-bundle/zipball/756310e6628b6dc9cfe66c81e37494fb470bc3bf",
-                "reference": "756310e6628b6dc9cfe66c81e37494fb470bc3bf",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-saml-bundle/zipball/2fa2d44e5a005c2044b7898d9624648a4850b129",
+                "reference": "2fa2d44e5a005c2044b7898d9624648a4850b129",
                 "shasum": ""
             },
             "require": {
@@ -1028,7 +1028,7 @@
                 "stepup",
                 "surfnet"
             ],
-            "time": "2020-02-20T12:24:28+00:00"
+            "time": "2020-03-17T13:59:34+00:00"
         },
         {
             "name": "symfony/asset",
@@ -5155,6 +5155,7 @@
             ],
             "description": "This tool check syntax of PHP files about 20x faster than serial check.",
             "homepage": "https://github.com/JakubOnderka/PHP-Parallel-Lint",
+            "abandoned": "php-parallel-lint/php-parallel-lint",
             "time": "2018-02-24T15:31:20+00:00"
         },
         {

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -31,4 +31,3 @@ services:
     Surfnet\AzureMfa\Application\Service\AuthenticationHelper:
         arguments:
             $regex: '%ra_issuer_entity_id_regex%'
-            $authenticationService: '@Surfnet\GsspBundle\Service\AuthenticationService'

--- a/src/Surfnet/AzureMfa/Application/Service/AuthenticationHelper.php
+++ b/src/Surfnet/AzureMfa/Application/Service/AuthenticationHelper.php
@@ -39,15 +39,21 @@ class AuthenticationHelper implements AuthenticationHelperInterface
      */
     private $authenticationService;
 
-    public function __construct(string $regex, AuthenticationService $authenticationService)
+    public function __construct(string $regex, AuthenticationService $authService)
     {
         $this->regex = $regex;
-        $this->authenticationService = $authenticationService;
+        $this->authenticationService = $authService;
     }
 
     public function useForceAuthn() : bool
     {
-        $issuer = $this->authenticationService->getIssuer();
+        $issuer = '';
+        $requesterIds = $this->authenticationService->getScopingRequesterIds();
+        // If Scoping=>RequesterIDs are set, get the first entry, which is the original issuer of the authn request.
+        if (!empty($requesterIds)) {
+            $issuer = array_shift($requesterIds);
+        }
+
         if (preg_match($this->regex, $issuer) == false) {
             return false;
         }

--- a/tests/Functional/Features/Context/WebContext.php
+++ b/tests/Functional/Features/Context/WebContext.php
@@ -214,7 +214,7 @@ class WebContext implements Context, KernelAwareContext
         $authnRequest->setIssuer('https://azure-mfa.stepup.example.com/saml/metadata');
         $authnRequest->setNameId(['Value' => $nameId]);
         $authnRequest->setProtocolBinding(Constants::BINDING_HTTP_REDIRECT);
-
+        $authnRequest->setRequesterID(['https://azure-mfa.stepup.example.com/saml/metadata']);
         // Sign with random key, does not mather for now.
         $authnRequest->setSignatureKey(
             $this->loadPrivateKey($this->getIdentityProvider()->getPrivateKey(PrivateKey::NAME_DEFAULT))

--- a/tests/Unit/Application/Institution/Service/AuthenticationHelperTest.php
+++ b/tests/Unit/Application/Institution/Service/AuthenticationHelperTest.php
@@ -33,10 +33,10 @@ class AuthenticationHelperTest extends TestCase
      */
     public function test_domain_matching_works_as_intended(string $domainName) : void
     {
-        $authenticationService = m::mock(AuthenticationService::class);
-        $authenticationService->shouldReceive('getIssuer')
-            ->andReturn($domainName);
-        $helper = new AuthenticationHelper($this->regex, $authenticationService);
+        $authService = m::mock(AuthenticationService::class);
+        $authService->shouldReceive('getScopingRequesterIds')
+            ->andReturn([$domainName]);
+        $helper = new AuthenticationHelper($this->regex, $authService);
 
         $this->assertTrue($helper->useForceAuthn());
     }
@@ -47,10 +47,10 @@ class AuthenticationHelperTest extends TestCase
      */
     public function test_domain_matching_works_as_intended_on_invalid_uris(string $domainName) : void
     {
-        $authenticationService = m::mock(AuthenticationService::class);
-        $authenticationService->shouldReceive('getIssuer')
-            ->andReturn($domainName);
-        $helper = new AuthenticationHelper($this->regex, $authenticationService);
+        $authService = m::mock(AuthenticationService::class);
+        $authService->shouldReceive('getScopingRequesterIds')
+            ->andReturn([$domainName]);
+        $helper = new AuthenticationHelper($this->regex, $authService);
 
         $this->assertFalse($helper->useForceAuthn());
     }
@@ -71,5 +71,6 @@ class AuthenticationHelperTest extends TestCase
         yield ['https://example.a/vetting-procedure/gssf/azuremfa/metadata'];
         yield ['https://example.com/vetting-procedure/gssf/azuremfa/metadataa'];
         yield ['https://example.it\'s-invalid.com/vetting-procedure/gssf/azuremfa/metadata'];
+        yield [''];
     }
 }

--- a/tests/Unit/Application/Institution/Service/FakeSspContainer.php
+++ b/tests/Unit/Application/Institution/Service/FakeSspContainer.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\AzureMfa\Test\Unit\Application\Institution\Service;
+
+use SAML2\Compat\AbstractContainer;
+
+class FakeSspContainer extends AbstractContainer
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function getLogger()
+    {
+        // TODO: Implement getLogger() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generateId()
+    {
+        return 'abcdefghijklmnopqrstuvwxyz';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function debugMessage($message, $type)
+    {
+        // TODO: Implement debugMessage() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function redirect($url, $data = [])
+    {
+        // TODO: Implement redirect() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function postRedirect($url, $data = [])
+    {
+        // TODO: Implement postRedirect() method.
+    }
+}


### PR DESCRIPTION
Gateway will set scoping on the authnrequest, it contains the SP where the original authnrequest originated from.

This value is used to judge if this is an RA authentication (vetting procedure). If this is the case, the ForceAuthn is added to the outgoing request.

This is deemed POC code and should be reviewed carefully, any additional defence in-depth changes are welcome but might be postponed until the team decides how to move forward with the POC.

See:
https://www.pivotaltracker.com/story/show/171101458
https://github.com/OpenConext/Stepup-gssp-bundle/pull/33
https://github.com/OpenConext/Stepup-saml-bundle/pull/97