### PR TITLE
Mail domain extraction leads to unexpected results

### DIFF
--- a/src/Surfnet/AzureMfa/Domain/EmailAddress.php
+++ b/src/Surfnet/AzureMfa/Domain/EmailAddress.php
@@ -48,6 +48,6 @@ class EmailAddress
     public function getDomain() : string
     {
         $explosion = explode('@', $this->emailAddress);
-        return strtolower($explosion[1]);
+        return strtolower(end($explosion));
     }
 }


### PR DESCRIPTION
When the attacker provides an email address like "bla+@victim.com@"@attacker.com,
the function would extract victim.com instead of attacker.com. This fix wil always use the last part of the email-address.
See : https://www.pivotaltracker.com/story/show/172354949