### PR TITLE
Do validation on emailaddress and not NameId

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -27,5 +27,6 @@ default:
             contexts:
                 - Surfnet\AzureMfa\Test\Features\Context\WebContext
                 - Surfnet\AzureMfa\Test\Features\Context\ErrorReportContext
+                - Surfnet\AzureMfa\Test\Features\Context\MockIDPContext
                 - Behat\MinkExtension\Context\MinkContext
                 - behatch:context:xml

--- a/dev/Controller/MockAzureMfaController.php
+++ b/dev/Controller/MockAzureMfaController.php
@@ -63,22 +63,41 @@ class MockAzureMfaController extends AbstractController
         }
 
         try {
+            $status = $request->get('status');
+
             // Check binding
-            if (!$request->isMethod(Request::METHOD_GET)) {
+            if (!$request->isMethod(Request::METHOD_GET) &&  !$status) {
                 throw new BadRequestHttpException(sprintf(
                     'Could not receive AuthnRequest from HTTP Request: expected a GET method, got %s',
                     $request->getMethod()
                 ));
             }
 
+            // show possible saml response status to return
+            if (!$status) {
+                // Present response
+                $body = $this->twig->render(
+                    'dev/mock-acs.html.twig',
+                    [
+                        'action' => $request->getUri(),
+                        'responses' => [
+                            'success',
+                            'user-cancelled',
+                            'unknown',
+                        ],
+                    ]
+                );
+                return new Response($body);
+            }
+
             // Parse available responses
-            $responses = $this->getAvailableResponses($request);
+            $response = $this->getSelectedResponse($request, $status);
 
             // Present response
             $body = $this->twig->render(
-                'dev/mock-acs.html.twig',
+                'dev/mock-acs-post.html.twig',
                 [
-                    'responses' => $responses,
+                    'response' => $response,
                 ]
             );
 
@@ -92,35 +111,46 @@ class MockAzureMfaController extends AbstractController
 
     /**
      * @param Request $request
-     * @return mixed
-     * @throws Exception
+     * @param string $status
+     * @return array
      */
-    private function getAvailableResponses(Request $request)
+    private function getSelectedResponse(Request $request, $status)
     {
-        // Parse successful
-        $samlResponse = $this->mockStepupGateway->handleSsoSuccess($request, $this->getFullRequestUri($request));
-        $results['success'] = $this->getResponseData($request, $samlResponse);
+        switch (true) {
+            case ($status == 'success'):
+                // Parse successful
+                $rawAttributes = $request->get('attributes');
+                $attributes = $this->parseAttributes($rawAttributes);
 
-        // Parse user cancelled
-        $samlResponse = $this->mockStepupGateway->handleSsoFailure(
-            $request,
-            $this->getFullRequestUri($request),
-            Constants::STATUS_RESPONDER,
-            Constants::STATUS_AUTHN_FAILED,
-            'Authentication cancelled by user'
-        );
-        $results['user-cancelled'] = $this->getResponseData($request, $samlResponse);
+                $samlResponse = $this->mockStepupGateway->handleSsoSuccess($request, $this->getFullRequestUri($request), $attributes);
+                return $this->getResponseData($request, $samlResponse);
 
-        // Parse unknown
-        $samlResponse = $this->mockStepupGateway->handleSsoFailure(
-            $request,
-            $this->getFullRequestUri($request),
-            Constants::STATUS_RESPONDER,
-            Constants::STATUS_AUTHN_FAILED
-        );
-        $results['unknown'] = $this->getResponseData($request, $samlResponse);
+            case ($status == 'user-cancelled'):
+                // Parse user cancelled
+                $samlResponse = $this->mockStepupGateway->handleSsoFailure(
+                    $request,
+                    $this->getFullRequestUri($request),
+                    Constants::STATUS_RESPONDER,
+                    Constants::STATUS_AUTHN_FAILED,
+                    'Authentication cancelled by user'
+                );
+                return $this->getResponseData($request, $samlResponse);
 
-        return $results;
+            case ($status == 'unknown'):
+                // Parse unknown
+                $samlResponse = $this->mockStepupGateway->handleSsoFailure(
+                    $request,
+                    $this->getFullRequestUri($request),
+                    Constants::STATUS_RESPONDER,
+                    Constants::STATUS_AUTHN_FAILED
+                );
+                return $this->getResponseData($request, $samlResponse);
+            default:
+                throw new BadRequestHttpException(sprintf(
+                    'Could not create a response for status %s',
+                    $status
+                ));
+        }
     }
 
     /**
@@ -146,6 +176,59 @@ class MockAzureMfaController extends AbstractController
      */
     private function getFullRequestUri(Request $request)
     {
-        return $request->getSchemeAndHttpHost() . $request->getBasePath() . $request->getRequestUri();
+        return $request->getSchemeAndHttpHost() . $request->getBasePath() . $request->getPathInfo();
+    }
+
+    /**
+     * @param string $data
+     * @return array
+     */
+    private function parseAttributes($data)
+    {
+        @json_decode($data);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new BadRequestHttpException(sprintf(
+                'Could not parse the attributes because no valid json was given %s',
+                $data
+            ));
+        }
+
+        $data = json_decode($data, true);
+
+        $result = [];
+        foreach ($data as $attr) {
+            if (!array_key_exists('name', $attr)) {
+                throw new BadRequestHttpException(sprintf(
+                    'Could not parse the attributes because no valid name was given %s',
+                    json_encode($data)
+                ));
+            }
+            if (!array_key_exists('value', $attr)) {
+                throw new BadRequestHttpException(sprintf(
+                    'Could not parse the attributes because no valid value was given %s',
+                    json_encode($data)
+                ));
+            }
+
+            if (!is_array($attr['value'])) {
+                throw new BadRequestHttpException(sprintf(
+                    'Could not parse the attributes because a value should be an array with strings %s',
+                    json_encode($data)
+                ));
+            }
+
+            foreach ($attr['value'] as $value) {
+                if (!is_string($value)) {
+                    throw new BadRequestHttpException(sprintf(
+                        'Could not parse the attributes because if a value is an array it should consist of strings %s',
+                        json_encode($data)
+                    ));
+                }
+            }
+
+            $result[$attr['name']] = $attr['value'];
+        }
+
+        return $result;
     }
 }

--- a/dev/Mock/MockGateway.php
+++ b/dev/Mock/MockGateway.php
@@ -69,6 +69,7 @@ class MockGateway
      * @param Request $request
      * @param string $fullRequestUri
      * @return Response
+     * @throws \Exception
      */
     public function handleSsoSuccess(Request $request, $fullRequestUri)
     {
@@ -84,6 +85,7 @@ class MockGateway
         // handle success
         return $this->createSecondFactorOnlyResponse(
             $nameId,
+            $authnRequest->getNameId()->value,
             $destination,
             $authnContextClassRef,
             $requestId
@@ -113,16 +115,18 @@ class MockGateway
 
     /**
      * @param string $nameId
+     * @param string $emailAddress
      * @param string $destination The ACS location
      * @param string|null $authnContextClassRef The loa level
      * @param string $requestId The requestId
      * @return Response
      */
-    private function createSecondFactorOnlyResponse($nameId, $destination, $authnContextClassRef, $requestId)
+    private function createSecondFactorOnlyResponse($nameId, $emailAddress, $destination, $authnContextClassRef, $requestId)
     {
         return $this->createNewAuthnResponse(
             $this->createNewAssertion(
                 $nameId,
+                $emailAddress,
                 $authnContextClassRef,
                 $destination,
                 $requestId
@@ -290,12 +294,13 @@ class MockGateway
 
     /**
      * @param string $nameId
+     * @param $emailAddress
      * @param string $authnContextClassRef
      * @param string $destination The ACS location
      * @param string $requestId The requestId
      * @return Assertion
      */
-    private function createNewAssertion($nameId, $authnContextClassRef, $destination, $requestId)
+    private function createNewAssertion($nameId,$emailAddress, $authnContextClassRef, $destination, $requestId)
     {
         $newAssertion = new Assertion();
         $newAssertion->setNotBefore($this->currentTime->getTimestamp());
@@ -307,6 +312,9 @@ class MockGateway
         $newAssertion->setNameId([
             'Format' => Constants::NAMEID_UNSPECIFIED,
             'Value' => $nameId,
+        ]);
+        $newAssertion->setAttributes([
+            'urn:mace:dir:attribute-def:emailAddress' => [$emailAddress]
         ]);
         $newAssertion->setValidAudiences([$this->gatewayConfiguration->getServiceProviderEntityId()]);
         $this->addAuthenticationStatementTo($newAssertion, $authnContextClassRef);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "serialize-javascript": "^2.1"
   },
   "resolutions": {
-    "js-yaml": "^3.13.1"
+    "js-yaml": "^3.13.1",
+    "yargs-parser": "^13.1.2"
   }
 }

--- a/src/Surfnet/AzureMfa/Application/Service/AzureMfaService.php
+++ b/src/Surfnet/AzureMfa/Application/Service/AzureMfaService.php
@@ -38,7 +38,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  */
 class AzureMfaService
 {
-    const SAML_EMAIL_ATTRIBUTE = 'urn:mace:dir:attribute-def:email';
+    const SAML_EMAIL_ATTRIBUTE = 'urn:mace:dir:attribute-def:mail';
 
     /**
      * @var EmailDomainMatchingService

--- a/src/Surfnet/AzureMfa/Domain/Exception/MailAttributeMismatchException.php
+++ b/src/Surfnet/AzureMfa/Domain/Exception/MailAttributeMismatchException.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\AzureMfa\Domain\Exception;
+
+use Exception;
+
+class MailAttributeMismatchException extends Exception
+{
+}

--- a/src/Surfnet/AzureMfa/Domain/Exception/MissingMailAttributeException.php
+++ b/src/Surfnet/AzureMfa/Domain/Exception/MissingMailAttributeException.php
@@ -20,6 +20,6 @@ namespace Surfnet\AzureMfa\Domain\Exception;
 
 use Exception;
 
-class InvalidMfaNameIdException extends Exception
+class MissingMailAttributeException extends Exception
 {
 }

--- a/src/Surfnet/AzureMfa/Infrastructure/Controller/DefaultController.php
+++ b/src/Surfnet/AzureMfa/Infrastructure/Controller/DefaultController.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\AzureMfa\Infrastructure\Controller;
 
+use Exception;
 use Psr\Log\LoggerInterface;
 use Surfnet\AzureMfa\Application\Service\AuthenticationHelperInterface;
 use Surfnet\AzureMfa\Application\Service\AzureMfaService;
@@ -27,7 +28,6 @@ use Surfnet\AzureMfa\Infrastructure\Form\EmailAddressDto;
 use Surfnet\AzureMfa\Infrastructure\Form\EmailAddressType;
 use Surfnet\GsspBundle\Service\AuthenticationService;
 use Surfnet\GsspBundle\Service\RegistrationService;
-use Surfnet\SamlBundle\Http\Exception\AuthnFailedSamlResponseException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -175,7 +175,7 @@ class DefaultController extends AbstractController
                 $this->azureMfaService->finishAuthentication($user->getUserId());
                 $this->authenticationService->authenticate();
             }
-        } catch (AuthnFailedSamlResponseException $e) {
+        } catch (Exception $e) {
             $this->logger->error('The authentication or registration failed. Rejecting the Azure MFA response.');
             $this->registrationService->reject($request->get('message'));
         }

--- a/templates/dev/mock-acs-post.html.twig
+++ b/templates/dev/mock-acs-post.html.twig
@@ -1,0 +1,21 @@
+<html>
+
+    <h2>Post SAML response back to SSO</h2>
+    <form method="post" action="{{ response.acu }}" id="postResponse">
+        <input type="hidden" name="SAMLResponse" value="{{ response.encodedResponse }}"/>
+        {% if response.relayState|length > 0 %}
+            <input type="hidden" name="RelayState" value="{{ response.relayState|escape }}"/>
+        {% endif %}
+        <input type="submit" value="Post"/>
+    </form>
+
+    <script type="text/javascript">
+        window.onload = function() {
+            setTimeout(
+                function() {
+                    document.forms["postResponse"].submit();
+                }, 1000);
+        };
+
+    </script>
+</html>

--- a/templates/dev/mock-acs.html.twig
+++ b/templates/dev/mock-acs.html.twig
@@ -1,22 +1,22 @@
 <html>
-<noscript>
-    <b>Note: </b> javascript is disabled, please click the button below to proceed
-</noscript>
-One moment please...
-<br/>
-TODO: Add emailaddress field to use instead of NameID
-<br/>
-{% for id, response in responses %}
-    <h2>{{ id }}</h2>
-    <form method="post" action="{{ response.acu }}">
-        <input type="hidden" name="SAMLResponse" value="{{ response.encodedResponse }}"/>
-        {% if response.relayState|length > 0 %}
-            <input type="hidden" name="RelayState" value="{{ response.relayState|escape }}"/>
-        {% endif %}
-        <input type="submit" class="hidden"/>
-        <noscript>
-            <input type="submit" value="Submit-{{ id }}"/>
-        </noscript>
+    <h2>Select response</h2>
+    <form method="post" action="{{ action }}">
+
+        <h3>Attributes</h3>
+        <textarea name="attributes" style="width:800px; height: 500px;">
+[
+{
+    "name":"urn:mace:dir:attribute-def:mail",
+    "value": [
+        "test@stepup.example.com"
+    ]
+}
+]
+        </textarea>
+        <br/>
+
+        {% for id, response in responses %}
+            <button name="status" value="{{ response }}" type="submit">{{ response }}</button><br/>
+        {% endfor %}
     </form>
-{% endfor %}
 </html>

--- a/templates/dev/mock-acs.html.twig
+++ b/templates/dev/mock-acs.html.twig
@@ -3,7 +3,9 @@
     <b>Note: </b> javascript is disabled, please click the button below to proceed
 </noscript>
 One moment please...
-
+<br/>
+TODO: Add emailaddress field to use instead of NameID
+<br/>
 {% for id, response in responses %}
     <h2>{{ id }}</h2>
     <form method="post" action="{{ response.acu }}">

--- a/tests/Functional/Features/Context/MockIDPContext.php
+++ b/tests/Functional/Features/Context/MockIDPContext.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Copyright 2019 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\AzureMfa\Test\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\MinkExtension\Context\MinkContext;
+
+class MockIDPCOntext implements Context
+{
+    /**
+     * @var MinkContext
+     */
+    protected $minkContext;
+
+    /**
+     * Fetch the required contexts.
+     *
+     * @BeforeScenario
+     */
+    public function gatherContexts(BeforeScenarioScope $scope)
+    {
+        $environment = $scope->getEnvironment();
+        $this->minkContext = $environment->getContext(MinkContext::class);
+    }
+
+    /**
+     * @Then /^the login with Azure MFA succeeds and the email addresses "(?P<emailAddresses>(?:[^"]|\\")*)" are released$/
+     */
+    public function theLoginToAzureMFASucceeds($emailAddresses)
+    {
+        $data = '[]';
+
+        if ($emailAddresses) {
+            $emailAddresses = explode(',', $emailAddresses);
+            $jsonMail = json_encode($emailAddresses);
+            $data = sprintf('[{"name":"urn:mace:dir:attribute-def:mail","value":%s}]', $jsonMail);
+        }
+
+        $this->minkContext->fillField('attributes', $data);
+
+        $this->minkContext->pressButton('success');
+        $this->minkContext->pressButton('Post');
+    }
+
+    /**
+     * @Then /^the login with Azure MFA gets cancelled$/
+     */
+    public function theLoginToAzureMFAGetsCancelled(){
+
+        $this->minkContext->pressButton('user-cancel');
+        $this->minkContext->pressButton('Post');
+    }
+
+    /**
+     * @Then /^the login with Azure MFA fails$/
+     */
+    public function theLoginToAzureMFAFails(){
+
+        $this->minkContext->pressButton('unknown');
+        $this->minkContext->pressButton('Post');
+    }
+
+}

--- a/tests/Functional/Features/authentication.feature
+++ b/tests/Functional/Features/authentication.feature
@@ -5,19 +5,19 @@ Feature: When an user needs to authenticate
   Scenario: The user authenticates successfully
     Given I send an authentication request request to "https://azure-mfa.stepup.example.com/saml/sso" with NameID "q2b27d-0000|user@stepup.example.com"
     And the received AuthNRequest should have the ForceAuthn attribute
-    And I press "Submit-success"
+    Given the login with Azure MFA succeeds and the email addresses "user@stepup.example.com" are released
     Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:Success"
     And the SAML Response should contain element "NameID" with value "q2b27d-0000|user@stepup.example.com"
 
   Scenario: Authentication fails on the Azure MFA side
     Given I send an authentication request request to "https://azure-mfa.stepup.example.com/saml/sso" with NameID "q2b27d-0000|user@stepup.example.com"
-    And I press "Submit-user-cancelled"
+    And the login with Azure MFA gets cancelled
     Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"
 
   Scenario: Authentication fails because of unknown user on the Azure MFA side
     Given I send an authentication request request to "https://azure-mfa.stepup.example.com/saml/sso" with NameID "q2b27d-0000|user@stepup.example.com"
-    And I press "Submit-unknown"
+    And the login with Azure MFA fails
     Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"

--- a/tests/Functional/Features/locale.feature
+++ b/tests/Functional/Features/locale.feature
@@ -22,7 +22,7 @@ Feature: When an user needs switch it's preferred locale
     Then I should see "Registration"
     And I fill in "Email address" with "test-user@institution-a.example.com"
     When I press "Submit"
-    And I press "Submit-success"
+    Given the login with Azure MFA succeeds and the email addresses "test-user@institution-a.example.com" are released
     Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:Success"
     And the SAML Response should contain element "NameID" with value containing "test-user@institution-a.example.com"

--- a/tests/Functional/Features/registration.feature
+++ b/tests/Functional/Features/registration.feature
@@ -8,17 +8,26 @@ Feature: When an user needs to register for a new token
     Then I should see "Registration"
     And I fill in "Email address" with "test-user@institution-a.example.com"
     When I press "Submit"
-    And I press "Submit-success"
+    Given the login with Azure MFA succeeds and the email addresses "test-user@institution-a.example.com" are released
     Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:Success"
     And the SAML Response should contain element "NameID" with value containing "test-user@institution-a.example.com"
 
-  Scenario: When a user is registering a new token, authentication at Azure MFA fails
+  Scenario: When a user is registering a new token, and if an unknown mail address gets released authentication at Azure MFA fails
     Given I send a registration request request to "https://azure-mfa.stepup.example.com/saml/sso"
     Then I should see "Registration"
     And I fill in "Email address" with "test-user@institution-a.example.com"
     When I press "Submit"
-    And I press "Submit-user-cancelled"
+    Given the login with Azure MFA succeeds and the email addresses "unknown@institution-a.example.com" are released
+    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"
+
+  Scenario: When a user is registering a new token, and if no mail attribute gets released authentication at Azure MFA fails
+    Given I send a registration request request to "https://azure-mfa.stepup.example.com/saml/sso"
+    Then I should see "Registration"
+    And I fill in "Email address" with "test-user@institution-a.example.com"
+    When I press "Submit"
+    Given the login with Azure MFA succeeds and the email addresses "" are released
     Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"
 
@@ -27,7 +36,16 @@ Feature: When an user needs to register for a new token
     Then I should see "Registration"
     And I fill in "Email address" with "test-user@institution-a.example.com"
     When I press "Submit"
-    And I press "Submit-unknown"
+    And the login with Azure MFA gets cancelled
+    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"
+
+  Scenario: When a user is registering a new token, authentication at Azure MFA fails
+    Given I send a registration request request to "https://azure-mfa.stepup.example.com/saml/sso"
+    Then I should see "Registration"
+    And I fill in "Email address" with "test-user@institution-a.example.com"
+    When I press "Submit"
+    Given the login with Azure MFA fails
     Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"
 

--- a/tests/Functional/Features/sp_authentication.feature
+++ b/tests/Functional/Features/sp_authentication.feature
@@ -13,7 +13,7 @@ Feature: When an user needs to authenticate
 
     # The mock MFA client
     Then I should be on "https://azure-mfa.stepup.example.com/mock/sso"
-    Given I press "Submit-success"
+    Given the login with Azure MFA succeeds and the email addresses "user@stepup.example.com" are released
 
     # The MFA acs page.
     Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"

--- a/tests/Functional/Features/sp_registration.feature
+++ b/tests/Functional/Features/sp_registration.feature
@@ -20,7 +20,7 @@ Feature: When an user needs to register for a new token
 
     # The MFA SSO page
     Then I should be on "https://azure-mfa.stepup.example.com/mock/sso"
-    Given I press "Submit-success"
+    Given the login with Azure MFA succeeds and the email addresses "user@stepup.example.com" are released
 
     # The GSSP acs page.
     Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2750,6 +2750,11 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+esprima@^2.6.0:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+  integrity sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=
+
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
@@ -3998,9 +4003,9 @@ isstream@~0.1.2:
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
 jquery@~3:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
-  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.5.2"
@@ -4017,13 +4022,21 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.13.1, js-yaml@~3.7.0:
+js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@~3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
+  integrity sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^2.6.0"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -7518,36 +7531,13 @@ yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yargs-parser@^11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
-  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-12.0.0.tgz#18aa348854747dfe1002d01bd87d65df10d40a84"
-  integrity sha512-WQM8GrbF5TKiACr7iE3I2ZBNC7qC9taKPMfjJaMD2LkOJQhIctASxKXdFAOPim/m47kgAQBVIaPlFjnRdkol7w==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^13.1.0:
+yargs-parser@^11.1.1, yargs-parser@^12.0.0, yargs-parser@^13.1.0, yargs-parser@^13.1.2, yargs-parser@^5.0.0:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
-
-yargs-parser@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
-  integrity sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=
-  dependencies:
-    camelcase "^3.0.0"
 
 yargs@12.0.5:
   version "12.0.5"


### PR DESCRIPTION
The validation of a succesful response should be done
on the email attribute and not the NameID of the response.