### PR TITLE
Update step definition to use Mink's default context

### DIFF
--- a/tests/Functional/Features/sp_registration.feature
+++ b/tests/Functional/Features/sp_registration.feature
@@ -15,8 +15,8 @@ Feature: When an user needs to register for a new token
     And I should see "Registration"
 
     # GSSP assigns a subject name id to the user
-    Given I fill in "email_address_emailAddress" with "user@stepup.example.com"
-    When I press "email_address_submit"
+    When I fill in "email_address_emailAddress" with "user@stepup.example.com"
+    And I press "email_address_submit"
 
     # The MFA SSO page
     Then I should be on "https://azure-mfa.stepup.example.com/mock/sso"


### PR DESCRIPTION
Behat could find the step definition and therefor the tests failed.
This uses the @When and @And for the fillField step