### PR TITLE
Use consistent naming for the vhost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
   chrome: stable
 
   hosts:
-    - azure-mfa.stepup.example.com
+    - azuremfa.stepup.example.com
   apt:
     packages:
       - cmake
@@ -27,7 +27,7 @@ before_script:
   - export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
 
   # configure ssl
-  - sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/certs/azure-mfa.key -out /etc/ssl/certs/azure-mfa.crt -subj "/C=NL/ST=Netherlands/L=Amsterdam/O=TEST/CN=azure-mfa.stepup.example.com"
+  - sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/certs/azuremfa.key -out /etc/ssl/certs/azuremfa.crt -subj "/C=NL/ST=Netherlands/L=Amsterdam/O=TEST/CN=azuremfa.stepup.example.com"
   - sudo apt-get update
   - sudo apt-get install apache2 libapache2-mod-fastcgi
   - export PHP_VERSION=$(phpenv version-name)
@@ -69,8 +69,8 @@ before_script:
   - ps aux | grep php-fpm
   - netstat -an | grep :9000
   # Test if the website is actually running
-  - curl --insecure https://azure-mfa.stepup.example.com
-  - curl --insecure https://azure-mfa.stepup.example.com/fonts/FontAwesome.otf
+  - curl --insecure https://azuremfa.stepup.example.com
+  - curl --insecure https://azuremfa.stepup.example.com/fonts/FontAwesome.otf
 
 script:
   - composer test

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Locale user preference
 ----------------------
 
 The default locale is based on the user agent. When the user switches its locale the selected preference is stored inside a
-browser cookie (stepup_locale). The cookie is set on naked domain of the requested domain (for azure-mfa.stepup.example.com this is example.com).
+browser cookie (stepup_locale). The cookie is set on naked domain of the requested domain (for azuremfa.stepup.example.com this is example.com).
 
 Authentication and registration flows
 -------------------------------------
 
 The application provides internal (SpBundle) and a remote service provider. Instructions for this are given 
-on the homepage of this example project [Homepage](https://azure-mfa.stepup.example.com/app_dev.php/).
+on the homepage of this example project [Homepage](https://azuremfa.stepup.example.com/app_dev.php/).
 
 ![flow](docs/flow.png)
 <!---
@@ -106,7 +106,7 @@ for production
 
 If everything goes as planned you can go to:
 
-[https://azure-mfa.stepup.example.com](https://azure-mfa.stepup.example.com/app_dev.php)
+[https://azuremfa.stepup.example.com](https://azuremfa.stepup.example.com/app_dev.php)
 
 
 Configuring institutions using Azure MFA 

--- a/behat.yml
+++ b/behat.yml
@@ -8,7 +8,7 @@ default:
                 bootstrap: tests/Functional/Features/bootstrap/bootstrap.php
                 class: Surfnet\AzureMfa\Infrastructure\Kernel
         Behat\MinkExtension:
-            base_url: https://azure-mfa.stepup.example.com
+            base_url: https://azuremfa.stepup.example.com
             default_session: 'symfony2'
             goutte:
                guzzle_parameters:

--- a/config/packages/dev/services.yaml
+++ b/config/packages/dev/services.yaml
@@ -18,8 +18,8 @@ services:
 
     Dev\Mock\MockConfiguration:
         arguments:
-            $identityProviderEntityId: 'https://azure-mfa.stepup.example.com/mock/idp/metadata'
-            $serviceProviderEntityId: 'https://azure-mfa.stepup.example.com/saml/metadata'
+            $identityProviderEntityId: 'https://azuremfa.stepup.example.com/mock/idp/metadata'
+            $serviceProviderEntityId: 'https://azuremfa.stepup.example.com/saml/metadata'
             $privateKeyPath: '%saml_idp_privatekey%'
             $publicCertPath: '%saml_idp_publickey%'
 

--- a/config/packages/dev/surfnet_saml.yaml
+++ b/config/packages/dev/surfnet_saml.yaml
@@ -20,6 +20,6 @@ surfnet_saml:
       - entity_id: "%saml_remote_sp_entity_id%"
         certificate_file: "%saml_remote_sp_certificate%"
         assertion_consumer_service_url: "%saml_remote_sp_acs%"
-      - entity_id: https://azure-mfa.stepup.example.com/saml/metadata
+      - entity_id: https://azuremfa.stepup.example.com/saml/metadata
         certificate_file: "%saml_idp_publickey%"
-        assertion_consumer_service_url: https://azure-mfa.stepup.example.com/demo/sp/acs
+        assertion_consumer_service_url: https://azuremfa.stepup.example.com/demo/sp/acs

--- a/config/packages/institutions.yaml.dist
+++ b/config/packages/institutions.yaml.dist
@@ -4,8 +4,8 @@ parameters:
     data: # The root node
       institutions:
         institution-a.example.com: # The institution identifier (schacHomeOrganization)
-          entity_id: 'https://azure-mfa.stepup.example.com/mock/metadata' # The Entity Id of the remote Azure MFA endpoint
-          sso_location: 'https://azure-mfa.stepup.example.com/mock/sso' # Location of the Azure MFA endpoint
+          entity_id: 'https://azuremfa.stepup.example.com/mock/metadata' # The Entity Id of the remote Azure MFA endpoint
+          sso_location: 'https://azuremfa.stepup.example.com/mock/sso' # Location of the Azure MFA endpoint
           certificates:
             - |
                 -----BEGIN CERTIFICATE-----
@@ -38,8 +38,8 @@ parameters:
             - 'institution-a.example.com'
             - '*.stepup.example.com' # Wildcards are allowed
         institution-b.example.com: # The institution identifier (schacHomeOrganization)
-          entity_id: 'https://azure-mfa.stepup.example.com/mock/metadata' # The Entity Id of the remote Azure MFA endpoint
-          sso_location: 'https://azure-mfa.stepup.example.com/mock/sso' # Location of the Azure MFA endpoint
+          entity_id: 'https://azuremfa.stepup.example.com/mock/metadata' # The Entity Id of the remote Azure MFA endpoint
+          sso_location: 'https://azuremfa.stepup.example.com/mock/sso' # Location of the Azure MFA endpoint
           certificates:
             - |
               -----BEGIN CERTIFICATE-----
@@ -72,7 +72,7 @@ parameters:
           is_azure_ad: true
         harting-college.nl:
           sso_location: 'https://adfs.harting-college.nl/adfs/ls/'
-          entity_id: 'https://azure-mfa.stepup.example.com/mock/metadata' # The Entity Id of the remote Azure MFA endpoint
+          entity_id: 'https://azuremfa.stepup.example.com/mock/metadata' # The Entity Id of the remote Azure MFA endpoint
           certificates:
             - |
               -----BEGIN CERTIFICATE-----

--- a/config/packages/test/parameters.yaml
+++ b/config/packages/test/parameters.yaml
@@ -1,4 +1,4 @@
 parameters:
     # overridden for test (behat)
     saml_remote_sp_certificate: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_publickey.cer'
-    ra_issuer_entity_id_regex: '@@^https://azure-mfa.stepup.example.com/saml/metadata$@'
+    ra_issuer_entity_id_regex: '@@^https://azuremfa.stepup.example.com/saml/metadata$@'

--- a/config/packages/test/services.yaml
+++ b/config/packages/test/services.yaml
@@ -18,8 +18,8 @@ services:
 
     Dev\Mock\MockConfiguration:
         arguments:
-            $identityProviderEntityId: 'https://azure-mfa.stepup.example.com/mock/idp/metadata'
-            $serviceProviderEntityId: 'https://azure-mfa.stepup.example.com/saml/metadata'
+            $identityProviderEntityId: 'https://azuremfa.stepup.example.com/mock/idp/metadata'
+            $serviceProviderEntityId: 'https://azuremfa.stepup.example.com/saml/metadata'
             $privateKeyPath: '%saml_idp_privatekey%'
             $publicCertPath: '%saml_idp_publickey%'
 

--- a/config/packages/test/surfnet_saml.yaml
+++ b/config/packages/test/surfnet_saml.yaml
@@ -20,7 +20,7 @@ surfnet_saml:
       - entity_id: "%saml_remote_sp_entity_id%"
         certificate_file: "%saml_remote_sp_certificate%"
         assertion_consumer_service_url: "%saml_remote_sp_acs%"
-      - entity_id: https://azure-mfa.stepup.example.com/saml/metadata
+      - entity_id: https://azuremfa.stepup.example.com/saml/metadata
         certificate_file: "%saml_idp_publickey%"
-        assertion_consumer_service_url: https://azure-mfa.stepup.example.com/demo/sp/acs
+        assertion_consumer_service_url: https://azuremfa.stepup.example.com/demo/sp/acs
 

--- a/dev/Controller/SPController.php
+++ b/dev/Controller/SPController.php
@@ -54,8 +54,8 @@ final class SPController extends AbstractController
         $baseDir = dirname(__DIR__, 2);
         $this->serviceProvider = new ServiceProvider(
             [
-                'entityId' => 'https://azure-mfa.stepup.example.com/saml/metadata',
-                'assertionConsumerUrl' => 'https://azure-mfa.stepup.example.com/demo/sp/acs',
+                'entityId' => 'https://azuremfa.stepup.example.com/saml/metadata',
+                'assertionConsumerUrl' => 'https://azuremfa.stepup.example.com/demo/sp/acs',
                 'certificateFile' => $baseDir . '/vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_publickey.cer',
                 'privateKeys' => [
                     new PrivateKey(

--- a/homestead/Homestead.yaml
+++ b/homestead/Homestead.yaml
@@ -14,7 +14,7 @@ folders:
         type: "nfs"
 sites:
     -
-        map: azure-mfa.stepup.example.com
+        map: azuremfa.stepup.example.com
         to: /home/vagrant/code/public
         type: symfony4
 name: azure-mfa

--- a/tests/Functional/Features/Context/WebContext.php
+++ b/tests/Functional/Features/Context/WebContext.php
@@ -111,7 +111,7 @@ class WebContext implements Context, KernelAwareContext
     public function callIdentityProviderSSOActionWithAuthnRequest()
     {
         $this->minkContext->visit('https://pieter.aai.surfnet.nl/simplesamlphp/sp.php?sp=default-sp');
-        $this->minkContext->selectOption('idp', 'https://azure-mfa.stepup.example.com/saml/metadata');
+        $this->minkContext->selectOption('idp', 'https://azuremfa.stepup.example.com/saml/metadata');
         $this->minkContext->pressButton('Login');
     }
 
@@ -122,7 +122,7 @@ class WebContext implements Context, KernelAwareContext
     {
         /** @var RequestStack $stack */
         $stack = $this->kernel->getContainer()->get('request_stack');
-        $stack->push(Request::create('https://azure-mfa.stepup.example.com'));
+        $stack->push(Request::create('https://azuremfa.stepup.example.com'));
         $ip = $this->kernel->getContainer()->get('surfnet_saml.hosted.identity_provider');
         $stack->pop();
 
@@ -187,9 +187,9 @@ class WebContext implements Context, KernelAwareContext
     public function iSendARegistrationRequestRequestTo($destination)
     {
         $authnRequest = new AuthnRequest();
-        $authnRequest->setAssertionConsumerServiceURL('https://azure-mfa.stepup.example.com/saml/acs');
+        $authnRequest->setAssertionConsumerServiceURL('https://azuremfa.stepup.example.com/saml/acs');
         $authnRequest->setDestination($destination);
-        $authnRequest->setIssuer('https://azure-mfa.stepup.example.com/saml/metadata');
+        $authnRequest->setIssuer('https://azuremfa.stepup.example.com/saml/metadata');
         $authnRequest->setProtocolBinding(Constants::BINDING_HTTP_REDIRECT);
 
         // Sign with random key, does not mather for now.
@@ -208,12 +208,12 @@ class WebContext implements Context, KernelAwareContext
     public function iSendAnAuthenticationRequestRequestToWithNameID($destination, $nameId = "")
     {
         $authnRequest = new AuthnRequest();
-        $authnRequest->setAssertionConsumerServiceURL('https://azure-mfa.stepup.example.com/saml/acs');
+        $authnRequest->setAssertionConsumerServiceURL('https://azuremfa.stepup.example.com/saml/acs');
         $authnRequest->setDestination($destination);
-        $authnRequest->setIssuer('https://azure-mfa.stepup.example.com/saml/metadata');
+        $authnRequest->setIssuer('https://azuremfa.stepup.example.com/saml/metadata');
         $authnRequest->setNameId(['Value' => $nameId]);
         $authnRequest->setProtocolBinding(Constants::BINDING_HTTP_REDIRECT);
-        $authnRequest->setRequesterID(['https://azure-mfa.stepup.example.com/saml/metadata']);
+        $authnRequest->setRequesterID(['https://azuremfa.stepup.example.com/saml/metadata']);
         // Sign with random key, does not mather for now.
         $authnRequest->setSignatureKey(
             $this->loadPrivateKey($this->getIdentityProvider()->getPrivateKey(PrivateKey::NAME_DEFAULT))

--- a/tests/Functional/Features/authentication.feature
+++ b/tests/Functional/Features/authentication.feature
@@ -3,23 +3,23 @@ Feature: When an user needs to authenticate
   I need to send an AuthnRequest with a nameID to the Azure MFA GSSP IdP
 
   Scenario: The user authenticates successfully
-    Given I send an authentication request to "https://azure-mfa.stepup.example.com/saml/sso" with NameID "q2b27d-0000|user@stepup.example.com"
+    Given I send an authentication request to "https://azuremfa.stepup.example.com/saml/sso" with NameID "q2b27d-0000|user@stepup.example.com"
     And the received AuthNRequest should have the ForceAuthn attribute
     Given the login with Azure MFA succeeds and the following attributes are released:
       | name                                                       | value                   |
       | urn:mace:dir:attribute-def:mail                            | user@stepup.example.com |
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:Success"
     And the SAML Response should contain element "NameID" with value "q2b27d-0000|user@stepup.example.com"
 
   Scenario: Authentication fails on the Azure MFA side
-    Given I send an authentication request to "https://azure-mfa.stepup.example.com/saml/sso" with NameID "q2b27d-0000|user@stepup.example.com"
+    Given I send an authentication request to "https://azuremfa.stepup.example.com/saml/sso" with NameID "q2b27d-0000|user@stepup.example.com"
     And the login with Azure MFA gets cancelled
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"
 
   Scenario: Authentication fails because of unknown user on the Azure MFA side
-    Given I send an authentication request to "https://azure-mfa.stepup.example.com/saml/sso" with NameID "q2b27d-0000|user@stepup.example.com"
+    Given I send an authentication request to "https://azuremfa.stepup.example.com/saml/sso" with NameID "q2b27d-0000|user@stepup.example.com"
     And the login with Azure MFA fails
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"

--- a/tests/Functional/Features/azure-ad_authentication.feature
+++ b/tests/Functional/Features/azure-ad_authentication.feature
@@ -1,7 +1,7 @@
 Feature: When using AzureAD directly
 
   Scenario: When a user is authenticating a token
-    Given I send an authentication request to "https://azure-mfa.stepup.example.com/saml/sso" without NameID
+    Given I send an authentication request to "https://azuremfa.stepup.example.com/saml/sso" without NameID
     Then I should see "Registration"
     And I fill in "email_address_emailAddress" with "test-user@institution-b.example.com"
     When I press "email_address_submit"
@@ -9,16 +9,16 @@ Feature: When using AzureAD directly
       | name                                                       | value                                             |
       | urn:mace:dir:attribute-def:mail                            | test-user@institution-b.example.com               |
       | http://schemas.microsoft.com/claims/authnmethodsreferences | http://schemas.microsoft.com/claims/multipleauthn |
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:Success"
 
   Scenario: Should fail when a authnmethodsreferences attribute is not released
-    Given I send an authentication request to "https://azure-mfa.stepup.example.com/saml/sso" without NameID
+    Given I send an authentication request to "https://azuremfa.stepup.example.com/saml/sso" without NameID
     Then I should see "Registration"
     And I fill in "email_address_emailAddress" with "test-user@institution-b.example.com"
     When I press "email_address_submit"
     Given the login with Azure MFA succeeds and the following attributes are released:
       | name                                                       | value                                             |
       | urn:mace:dir:attribute-def:mail                            | test-user@institution-b.example.com               |
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"

--- a/tests/Functional/Features/azure-ad_registration.feature
+++ b/tests/Functional/Features/azure-ad_registration.feature
@@ -1,7 +1,7 @@
 Feature: When using AzureAD directly
 
   Scenario: When a user is registering a new token
-    Given I send a registration request to "https://azure-mfa.stepup.example.com/saml/sso"
+    Given I send a registration request to "https://azuremfa.stepup.example.com/saml/sso"
     Then I should see "Registration"
     And I fill in "email_address_emailAddress" with "test-user@institution-b.example.com"
     When I press "email_address_submit"
@@ -9,16 +9,16 @@ Feature: When using AzureAD directly
       | name                                                       | value                                             |
       | urn:mace:dir:attribute-def:mail                            | test-user@institution-b.example.com               |
       | http://schemas.microsoft.com/claims/authnmethodsreferences | http://schemas.microsoft.com/claims/multipleauthn |
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:Success"
 
   Scenario: Should fail when a authnmethodsreferences attribute is not released
-    Given I send a registration request to "https://azure-mfa.stepup.example.com/saml/sso"
+    Given I send a registration request to "https://azuremfa.stepup.example.com/saml/sso"
     Then I should see "Registration"
     And I fill in "email_address_emailAddress" with "test-user@institution-b.example.com"
     When I press "email_address_submit"
     Given the login with Azure MFA succeeds and the following attributes are released:
       | name                                                       | value                                             |
       | urn:mace:dir:attribute-def:mail                            | test-user@institution-b.example.com               |
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"

--- a/tests/Functional/Features/locale.feature
+++ b/tests/Functional/Features/locale.feature
@@ -5,16 +5,16 @@ Feature: When an user needs switch it's preferred locale
 
   Scenario: The user is presented the page in his preferred language based on stepup-locale cookie NL
     Given I have "nl" set as my stepup-locale cookie value
-    And I send a registration request to "https://azure-mfa.stepup.example.com/saml/sso"
+    And I send a registration request to "https://azuremfa.stepup.example.com/saml/sso"
     Then I should see "Registratie"
 
   Scenario: The user is presented the page in his preferred language based on stepup-locale cookie EN
     Given I have "en" set as my stepup-locale cookie value
-    And I send a registration request to "https://azure-mfa.stepup.example.com/saml/sso"
+    And I send a registration request to "https://azuremfa.stepup.example.com/saml/sso"
     Then I should see "Registration"
 
   Scenario: When a user is registering a new token and switches back and forth from English to Dutch language during registration
-    Given I send a registration request to "https://azure-mfa.stepup.example.com/saml/sso"
+    Given I send a registration request to "https://azuremfa.stepup.example.com/saml/sso"
     Then I should see "Registration"
     And I follow "NL"
     Then I should see "Registratie"
@@ -25,6 +25,6 @@ Feature: When an user needs switch it's preferred locale
     Given the login with Azure MFA succeeds and the following attributes are released:
       | name                                                       | value                               |
       | urn:mace:dir:attribute-def:mail                            | test-user@institution-a.example.com |
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:Success"
     And the SAML Response should contain element "NameID" with value containing "test-user@institution-a.example.com"

--- a/tests/Functional/Features/metadata.feature
+++ b/tests/Functional/Features/metadata.feature
@@ -11,4 +11,4 @@ Feature: Metadata endpoint
   Scenario: Metadata must include a SingleSignOnService
     When I go to "/saml/metadata"
     Then the response should be in XML
-    And the XML attribute "Location" on element "/md:EntityDescriptor/md:IDPSSODescriptor/md:SingleSignOnService" should be equal to "https://azure-mfa.stepup.example.com/saml/sso"
+    And the XML attribute "Location" on element "/md:EntityDescriptor/md:IDPSSODescriptor/md:SingleSignOnService" should be equal to "https://azuremfa.stepup.example.com/saml/sso"

--- a/tests/Functional/Features/registration.feature
+++ b/tests/Functional/Features/registration.feature
@@ -4,64 +4,64 @@ Feature: When an user needs to register for a new token
   I need to send an AuthnRequest to the identity provider
 
   Scenario: When a user is registering a new token
-    Given I send a registration request to "https://azure-mfa.stepup.example.com/saml/sso"
+    Given I send a registration request to "https://azuremfa.stepup.example.com/saml/sso"
     Then I should see "Registration"
     And I fill in "email_address_emailAddress" with "test-user@institution-a.example.com"
     When I press "email_address_submit"
     Given the login with Azure MFA succeeds and the following attributes are released:
       | name                                                       | value                               |
       | urn:mace:dir:attribute-def:mail                            | test-user@institution-a.example.com |
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:Success"
     And the SAML Response should contain element "NameID" with value containing "test-user@institution-a.example.com"
 
   Scenario: When a user is registering a new token, and if an unknown mail address gets released authentication at Azure MFA fails
-    Given I send a registration request to "https://azure-mfa.stepup.example.com/saml/sso"
+    Given I send a registration request to "https://azuremfa.stepup.example.com/saml/sso"
     Then I should see "Registration"
     And I fill in "email_address_emailAddress" with "test-user@institution-a.example.com"
     When I press "email_address_submit"
     Given the login with Azure MFA succeeds and the following attributes are released:
       | name                                                       | value                             |
       | urn:mace:dir:attribute-def:mail                            | unknown@institution-a.example.com |
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"
 
   Scenario: When a user is registering a new token, and if no mail attribute gets released authentication at Azure MFA fails
-    Given I send a registration request to "https://azure-mfa.stepup.example.com/saml/sso"
+    Given I send a registration request to "https://azuremfa.stepup.example.com/saml/sso"
     Then I should see "Registration"
     And I fill in "email_address_emailAddress" with "test-user@institution-a.example.com"
     When I press "email_address_submit"
     Given the login with Azure MFA succeeds and the following attributes are released:
       | name                                                       | value                             |
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"
 
   Scenario: When a user is registering a new token, authentication at Azure MFA fails
-    Given I send a registration request to "https://azure-mfa.stepup.example.com/saml/sso"
+    Given I send a registration request to "https://azuremfa.stepup.example.com/saml/sso"
     Then I should see "Registration"
     And I fill in "email_address_emailAddress" with "test-user@institution-a.example.com"
     When I press "email_address_submit"
     And the login with Azure MFA gets cancelled
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"
 
   Scenario: When a user is registering a new token, authentication at Azure MFA fails
-    Given I send a registration request to "https://azure-mfa.stepup.example.com/saml/sso"
+    Given I send a registration request to "https://azuremfa.stepup.example.com/saml/sso"
     Then I should see "Registration"
     And I fill in "email_address_emailAddress" with "test-user@institution-a.example.com"
     When I press "email_address_submit"
     Given the login with Azure MFA fails
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed"
 
   Scenario: Registration fails when an invalid email address is provided by the user
-    Given I send a registration request to "https://azure-mfa.stepup.example.com/saml/sso"
+    Given I send a registration request to "https://azuremfa.stepup.example.com/saml/sso"
     # Fill an email address that does not match any of the configured email domains
     Then I should see "Registration"
     And I fill in "email_address_emailAddress" with "test-user@institution-xample.com"
     When I press "email_address_submit"
     When I press "email_address_submit"
-    Then I should be on "https://azure-mfa.stepup.example.com/registration"
+    Then I should be on "https://azuremfa.stepup.example.com/registration"
     And I should see "The provided email address did not match any of our configured email domains."
 
   Scenario: When the user is redirected from an unknown service provider he should see an error page

--- a/tests/Functional/Features/sp_authentication.feature
+++ b/tests/Functional/Features/sp_authentication.feature
@@ -6,22 +6,22 @@ Feature: When an user needs to authenticate
   Scenario: When an user needs to register for a new token
 
     # The user clicks on authenticate button from the SP
-    And I am on "https://azure-mfa.stepup.example.com/demo/sp"
+    And I am on "https://azuremfa.stepup.example.com/demo/sp"
     Then I should see "Demo service provider"
     And I fill in "Subject NameID" with "q2b27d-0000|user@stepup.example.com"
     Given I press "Authenticate user"
 
     # The mock MFA client
-    Then I should be on "https://azure-mfa.stepup.example.com/mock/sso"
+    Then I should be on "https://azuremfa.stepup.example.com/mock/sso"
     Given the login with Azure MFA succeeds and the following attributes are released:
       | name                                                       | value                   |
       | urn:mace:dir:attribute-def:mail                            | user@stepup.example.com |
 
     # The MFA acs page.
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And I press "Submit"
 
     # Back at the SP.
-    Then I should be on "https://azure-mfa.stepup.example.com/demo/sp/acs"
+    Then I should be on "https://azuremfa.stepup.example.com/demo/sp/acs"
     And I should see "Demo Service provider ConsumerAssertionService endpoint"
     And I should see "q2b27d-0000|user@stepup.example.com"

--- a/tests/Functional/Features/sp_registration.feature
+++ b/tests/Functional/Features/sp_registration.feature
@@ -6,12 +6,12 @@ Feature: When an user needs to register for a new token
 
   Scenario: When an user needs to register for a new token
     # The user request a registration from the service provider
-    Given I am on "https://azure-mfa.stepup.example.com/demo/sp"
+    Given I am on "https://azuremfa.stepup.example.com/demo/sp"
     Then I should see "Demo service provider"
     When I press "Register user"
 
     # The user register himself at the IdP
-    Then I should be on "https://azure-mfa.stepup.example.com/registration"
+    Then I should be on "https://azuremfa.stepup.example.com/registration"
     And I should see "Registration"
 
     # GSSP assigns a subject name id to the user
@@ -19,17 +19,17 @@ Feature: When an user needs to register for a new token
     When I press "email_address_submit"
 
     # The MFA SSO page
-    Then I should be on "https://azure-mfa.stepup.example.com/mock/sso"
+    Then I should be on "https://azuremfa.stepup.example.com/mock/sso"
     Given the login with Azure MFA succeeds and the following attributes are released:
       | name                                                       | value                  |
       | urn:mace:dir:attribute-def:mail                            | user@stepup.example.com |
 
     # The GSSP acs page.
-    Then I should be on "https://azure-mfa.stepup.example.com/saml/sso_return"
+    Then I should be on "https://azuremfa.stepup.example.com/saml/sso_return"
     And I press "Submit"
 
     # Back at the SP.
-    Then I should be on "https://azure-mfa.stepup.example.com/demo/sp/acs"
+    Then I should be on "https://azuremfa.stepup.example.com/demo/sp/acs"
     And I should see "Demo Service provider ConsumerAssertionService endpoint"
     And I should see "urn:oasis:names:tc:SAML:2.0:status:Succes"
     And I should see a NameID with email address "user@stepup.example.com"

--- a/tests/Functional/WebTests/MockAzureMfaControllerTest.php
+++ b/tests/Functional/WebTests/MockAzureMfaControllerTest.php
@@ -216,8 +216,8 @@ class MockAzureMfaControllerTest extends WebTestCase
         $samlBundle = '';
         return new ServiceProvider(
             [
-                'entityId' => 'https://azure-mfa.stepup.example.com/saml/metadata',
-                'assertionConsumerUrl' => 'https://azure-mfa.stepup.example.com/demo/sp/acs',
+                'entityId' => 'https://azuremfa.stepup.example.com/saml/metadata',
+                'assertionConsumerUrl' => 'https://azuremfa.stepup.example.com/demo/sp/acs',
                 'certificateFile' => $this->publicKey,
                 'privateKeys' => [
                     new PrivateKey(
@@ -235,8 +235,8 @@ class MockAzureMfaControllerTest extends WebTestCase
         $samlBundle = '';
         return new IdentityProvider(
             [
-                'entityId' => 'https://azure-mfa.stepup.example.com/mock/idp/metadata',
-                'ssoUrl' => 'https://azure-mfa.stepup.example.com/mock/sso',
+                'entityId' => 'https://azuremfa.stepup.example.com/mock/idp/metadata',
+                'ssoUrl' => 'https://azuremfa.stepup.example.com/mock/sso',
                 'certificateFile' => $this->publicKey,
                 'privateKeys' => [
                     new PrivateKey(

--- a/travis-ci-apache.conf
+++ b/travis-ci-apache.conf
@@ -1,6 +1,6 @@
 <VirtualHost *:443>
 
-    ServerName azure-mfa.stepup.example.com
+    ServerName azuremfa.stepup.example.com
     DocumentRoot %TRAVIS_BUILD_DIR%/public
 
     SSLEngine on
@@ -8,8 +8,8 @@
     SSLProtocol All -SSLv2 -SSLv3
     SSLHonorCipherOrder On
     SSLCompression off
-    SSLCertificateFile /etc/ssl/certs/azure-mfa.crt
-    SSLCertificateKeyFile /etc/ssl/certs/azure-mfa.key
+    SSLCertificateFile /etc/ssl/certs/azuremfa.crt
+    SSLCertificateKeyFile /etc/ssl/certs/azuremfa.key
 
     <Directory "%TRAVIS_BUILD_DIR%/public">
         Options FollowSymLinks MultiViews ExecCGI


### PR DESCRIPTION
The prefered name is azuremfa which is also begin used in Stepup-VM.
This renames the vhost config to match vhost/domain names