### PR TITLE
Make email address client side validation work again.

### DIFF
--- a/src/Surfnet/AzureMfa/Infrastructure/Form/EmailAddressType.php
+++ b/src/Surfnet/AzureMfa/Infrastructure/Form/EmailAddressType.php
@@ -19,8 +19,8 @@
 namespace Surfnet\AzureMfa\Infrastructure\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,9 +29,9 @@ final class EmailAddressType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('emailAddress', TextType::class, [
+            ->add('emailAddress', EmailType::class, [
               'label' => 'page.registration.form.email.label',
-              'attr' => ['type' => 'email', 'autofocus' => true, 'placeholder' => 'page.registration.form.email.placeholder'],
+              'attr' => ['autofocus' => true, 'placeholder' => 'page.registration.form.email.placeholder'],
               'required' => true,
             ])
             ->add('submit', SubmitType::class, [


### PR DESCRIPTION
By adding the 'type="email"' in the attr array, the <input> tag
effectively gets two type= attributes in the HTML, text and email,
this is invalid HTML but more importantly makes client side validation
not work.

The server side validation presents an ugly error so fixing this
client side is useful.