### PR TITLE
Remove .env.dist from excludes in Composer Archive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,7 +133,6 @@
       "!/.env.local.php",
       "!/var/cache/prod",
       "!/public/build",
-      "/.env.dist",
       "/.github",
       "/.gitignore",
       "/symfony.lock",


### PR DESCRIPTION
I added that line in a cleanup attempt of the release tarbal. Turns out the deploy tasks relies on the .env.dist file to be present when installing the release.