### PR TITLE
Add azure domain hint

### DIFF
--- a/src/Surfnet/AzureMfa/Application/Service/AzureMfaService.php
+++ b/src/Surfnet/AzureMfa/Application/Service/AzureMfaService.php
@@ -159,6 +159,17 @@ class AzureMfaService
         // Create redirect response.
         $query = $authnRequest->buildRequestQuery();
 
+        // For Azure, add a "whr" query parameter with the domain of the user we want to authenticate.
+        if (!$azureMfaIdentityProvider->isAzureAD()) {
+            // EntraID does not accept a Subject like ADFS does, and there is no other way to pass the full user ID.
+            // The Windows home realm hint (whr) parameter can help bypass the Microsoft Account Picker
+            // (Home Realm Discovery) when the user has multiple accounts, thereby improving the user (SSO) experience.
+
+            // Get domain part of the user's email address (UPN) and use that as home realm
+            $domain = $user->getEmailAddress()->getDomain();
+            $query .= '&whr=' . urlencode($domain);
+        }
+
         return sprintf(
             '%s?%s',
             $destination->getUrl(),

--- a/src/Surfnet/AzureMfa/Application/Service/AzureMfaService.php
+++ b/src/Surfnet/AzureMfa/Application/Service/AzureMfaService.php
@@ -160,7 +160,7 @@ class AzureMfaService
         $query = $authnRequest->buildRequestQuery();
 
         // For Azure, add a "whr" query parameter with the domain of the user we want to authenticate.
-        if (!$azureMfaIdentityProvider->isAzureAD()) {
+        if ($azureMfaIdentityProvider->isAzureAD()) {
             // EntraID does not accept a Subject like ADFS does, and there is no other way to pass the full user ID.
             // The Windows home realm hint (whr) parameter can help bypass the Microsoft Account Picker
             // (Home Realm Discovery) when the user has multiple accounts, thereby improving the user (SSO) experience.


### PR DESCRIPTION
Add a domain hint to the SAML AuthnRequest HTTP-Redirect HTTP using a `whr`query string. The domain is taken from the user's email address that is known to the GSSP. 

This is a Microsoft Azure specific way to send the User domain (realm) to the Microsoft account picker.
Experimentally: 
* Without `whr`, the account picker is shown when a user is authenticated to more than one account in the current browser session, even if only one account can be used with the service. 
* When the `whr` query string is present, and the user has one account in the domain specified in `whr` and another account in a different domain, the account picker is not shown. This is in improvement in the user experience, because this allows SSO to work without user interaction.
* When `whr` query string is present, and the user has two accounts in the domain specified in `whr` and two other account in a different domains, the account picker is shown with only the accounts from the specified domain. This is still an improvement and for normal users it should be rare that they have multiple accounts in the same domain.

Implemented using info from https://learn.microsoft.com/en-us/answers/questions/855476/domain-hint-alternative-for-saml

Implementing this using IdPList entries is more complex, and does not remove the one domain limit, so I chose the simpler method.