### PR TITLE
Allow using multiple keys from the metadata endpoint

### DIFF
--- a/config/openconext/institutions.yaml.dist
+++ b/config/openconext/institutions.yaml.dist
@@ -75,6 +75,11 @@ parameters:
           email_domains: # A list of email domains that are used to identify registering users (addresses must match the email domain of the institution)
             - 'institution-c.example.com'
           is_azure_ad: true # AzureAD (Entra) does not accept a SAML subject, ADFS does require this
+        institution-d.example.com: # The institution identifier (schacHomeOrganization)
+          metadata_url: 'https://azuremfa.dev.openconext.local/mock/metadata-rollover'
+          email_domains: # A list of email domains that are used to identify registering users (addresses must match the email domain of the institution)
+            - 'institution-d.example.com'
+          is_azure_ad: true # AzureAD (Entra) does not accept a SAML subject, ADFS does require this
         harting-college.nl:
           sso_location: 'https://adfs.harting-college.nl/adfs/ls/'
           entity_id: 'https://azuremfa.dev.openconext.local/mock/metadata' # The Entity Id of the remote Azure MFA endpoint

--- a/dev/Controller/MockAzureMfaController.php
+++ b/dev/Controller/MockAzureMfaController.php
@@ -106,7 +106,28 @@ class MockAzureMfaController extends AbstractController
         $body = $this->twig->render(
             'dev/mock-metadata.xml.twig',
             [
-                'publickey' => $cert->getCertData(),
+                'publickeys' => [
+                    $cert->getCertData(),
+                ]
+            ]
+        );
+        return new Response($body);
+    }
+
+    /**
+     * This is the metadata action used
+     */
+    #[Route(path: '/mock/metadata-rollover', name: 'mock_metadata_rollover')]
+    public function metadataRollover(Request $request): SymfonyResponse
+    {
+        $cert = new Certificate($this->mockStepupGateway->getPublicCertificate());
+        $body = $this->twig->render(
+            'dev/mock-metadata.xml.twig',
+            [
+                'publickeys' => [
+                    "MIIEJTCCAw2gAwIBAgIJANug+o++1X5IMA0GCSqGSIb3DQEBCwUAMIGoMQswCQYDVQQGEwJOTDEQMA4GA1UECAwHVXRyZWNodDEQMA4GA1UEBwwHVXRyZWNodDEVMBMGA1UECgwMU1VSRm5ldCBCLlYuMRMwEQYDVQQLDApTVVJGY29uZXh0MRwwGgYDVQQDDBNTVVJGbmV0IERldmVsb3BtZW50MSswKQYJKoZIhvcNAQkBFhxzdXJmY29uZXh0LWJlaGVlckBzdXJmbmV0Lm5sMB4XDTE0MTAyMDEyMzkxMVoXDTE0MTExOTEyMzkxMVowgagxCzAJBgNVBAYTAk5MMRAwDgYDVQQIDAdVdHJlY2h0MRAwDgYDVQQHDAdVdHJlY2h0MRUwEwYDVQQKDAxTVVJGbmV0IEIuVi4xEzARBgNVBAsMClNVUkZjb25leHQxHDAaBgNVBAMME1NVUkZuZXQgRGV2ZWxvcG1lbnQxKzApBgkqhkiG9w0BCQEWHHN1cmZjb25leHQtYmVoZWVyQHN1cmZuZXQubmwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDXuSSBeNJY3d4p060oNRSuAER5nLWT6AIVbv3XrXhcgSwc9m2b8u3ksp14pi8FbaNHAYW3MjlKgnLlopYIylzKD/6Ut/clEx67aO9Hpqsc0HmIP0It6q2bf5yUZ71E4CN2HtQceO5DsEYpe5M7D5i64kS2A7e2NYWVdA5Z01DqUpQGRBc+uMzOwyif6StBiMiLrZH3n2r5q5aVaXU4Vy5EE4VShv3Mp91sgXJj/v155fv0wShgl681v8yf2u2ZMb7NKnQRA4zM2Ng2EUAyy6PQ+Jbn+rALSm1YgiJdVuSlTLhvgwbiHGO2XgBi7bTHhlqSrJFK3Gs4zwIsop/XqQRBAgMBAAGjUDBOMB0GA1UdDgQWBBQCJmcoa/F7aM3jIFN7Bd4uzWRgzjAfBgNVHSMEGDAWgBQCJmcoa/F7aM3jIFN7Bd4uzWRgzjAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBd80GpWKjp1J+Dgp0blVAox1s/WPWQlex9xrx1GEYbc5elp3svS+S82s7dFm2llHrrNOBt1HZVC+TdW4f+MR1xq8O5lOYjDRsosxZc/u9jVsYWYc3M9bQAx8VyJ8VGpcAK+fLqRNabYlqTnj/t9bzX8fS90sp8JsALV4g84Aj0G8RpYJokw+pJUmOpuxsZN5U84MmLPnVfmrnuCVh/HkiLNV2c8Pk8LSomg6q1M1dQUTsz/HVxcOhHLj/owwh3IzXf/KXV/E8vSYW8o4WWCAnruYOWdJMI4Z8NG1Mfv7zvb7U3FL1C/KLV04DqzALXGj+LVmxtDvuxqC042apoIDQV",
+                    $cert->getCertData(),
+                ],
             ]
         );
         return new Response($body);

--- a/src/Surfnet/AzureMfa/Infrastructure/Entity/AzureMfaIdentityProvider.php
+++ b/src/Surfnet/AzureMfa/Infrastructure/Entity/AzureMfaIdentityProvider.php
@@ -20,7 +20,9 @@ declare(strict_types = 1);
 
 namespace Surfnet\AzureMfa\Infrastructure\Entity;
 
+use SAML2\Certificate\X509;
 use Surfnet\AzureMfa\Domain\Institution\Collection\CertificateCollection;
+use Surfnet\AzureMfa\Domain\Institution\ValueObject\Certificate;
 use Surfnet\AzureMfa\Domain\Institution\ValueObject\Destination;
 use Surfnet\AzureMfa\Domain\Institution\ValueObject\EntityId;
 use Surfnet\AzureMfa\Domain\Institution\ValueObject\IdentityProviderInterface;
@@ -34,11 +36,17 @@ class AzureMfaIdentityProvider extends IdentityProvider implements IdentityProvi
         private readonly CertificateCollection $certificates,
         bool $isAzureAD
     ) {
+        $keys = array_map(fn (Certificate $cert) => [
+            'encryption'      => false,
+            'signing'         => true,
+            'type'            => 'X509Certificate',
+            'X509Certificate' => $cert->getCertData(),
+        ], $certificates->getCertificates());
+
         $configuration = [
-            // The entityId is not configured in the
             'entityId' => $entityId->getEntityId(),
             'ssoUrl' => $destination->getUrl(),
-            'certificateData' => $certificates->first()->getCertData(),
+            'keys' => $keys,
             'isAzureAD' => $isAzureAD,
         ];
 

--- a/templates/dev/mock-metadata.xml.twig
+++ b/templates/dev/mock-metadata.xml.twig
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <EntityDescriptor ID="_a35331bd-8793-48f6-ba2f-617c3300d903"
-                  entityID="https://institution-c.example.com/"
+                  entityID="https://institution-metadata.example.com/"
                   xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
     <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        {% for publickey in publickeys %}
         <KeyDescriptor use="signing">
             <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
                 <X509Data>
@@ -12,6 +13,7 @@
                 </X509Data>
             </KeyInfo>
         </KeyDescriptor>
+        {% endfor %}
         <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
                              Location="https://azuremfa.dev.openconext.local/mock/sso"/>
     </IDPSSODescriptor>

--- a/tests/Functional/Features/Context/WebContext.php
+++ b/tests/Functional/Features/Context/WebContext.php
@@ -236,11 +236,11 @@ class WebContext implements Context
     /**
      * @Given /^I have an invalid cached identity provider for "([^"]*)"$/
      */
-    public function iHaveOldCertificateDataForInstitution($institution) {
+    public function iHaveAnInvalidCertificateDataForInstitution($institution) {
         file_put_contents(__DIR__ . '/../../../../federation-metadata/' . $institution . '.cache',
         '{
             "updated": "2025-06-05T15:49:55+02:00",
-            "entity_id": "https:\/\/institution-c.example.com\/",
+            "entity_id": "https:\/\/'.$institution.'\/",
             "sso_location": "https:\/\/azuremfa.dev.openconext.local\/mock\/sso",
             "certificates": [
                 "MIIEEzCCAnsCFEow2E90q1t\/\/LDuqkgF2zo7VNo4MA0GCSqGSIb3DQEBCwUAMEYxGzAZBgNVBAMMEkF6dXJlLU1GQSBHU1NQIElkUDEnMCUGA1UECgweRGV2ZWxvcG1lbnQgRG9ja2VyIGVudmlyb25tZW50MB4XDTIzMDUyNTA5MzMyM1oXDTI4MDUyMzA5MzMyM1owRjEbMBkGA1UEAwwSQXp1cmUtTUZBIEdTU1AgSWRQMScwJQYDVQQKDB5EZXZlbG9wbWVudCBEb2NrZXIgZW52aXJvbm1lbnQwggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQCWaoXdTdU3N0RL2jK\/88PEN3jwyyz7AFJX64Rfx48CtCsI3Hze+0i+0KQgILsVU91kKujllFBM6N4V5PKQ+9Z5zafJeuhT80zQ9jcHVxyQoKi30438fBGzlAKD9hGojG7DwjKopK+96Eawvu90KCxf8q7STh50n8dO6hnxWtE8RGk5a9R2cMDxEuOlvrW2B8Ih+EVCT3OmOsCQdp31TuTt5x3xLxmY\/04mGGPpQi9PBV38O2uTd4G2mbqGqNGx6S6iPAMgh6u4NVmg03iqBKkFJgQvNRCdif+gMQTKEW0mJwr62PrEQrPBoBphgCpJNF9pnEy\/+mdWiKCo8lvVxiPGQaaKyoNvZEt1IROwp8Ga2gLEoFjtcMcodnLgudusDOCH6Idp0CtuTkrf3hLIxKjQMOFTCiCmOCtMlJZa9+l7LbhzEGcJUcHH0i1k+ufqUhOSBrrfKoiohixAnW+bayqymef+Zy32YoT+\/LDjoP\/vyMrNnRwpwqguPMwBF+HWgwUCAwEAATANBgkqhkiG9w0BAQsFAAOCAYEAReFJH\/X+PyA8cFe6RdCgyTbuRuq2rTgadKpqfhhbXlwcOTh8rEpevqFf8tequegCj7fFZgz+hIL075ZsEcZwk2N8F8m32cVjmYHar2rLsYEkqhEc\/yCUjyGffqUeZBVmdUnUM6ggGsIHqcjTvrNhmFrh3ManebvZkjvDyJCkrwUOGYvCpbFjXa4CW1Rp+I0+e7HnQeyFW3p+3T0SAmdo3eJEZLhRsMm\/YLcyCW7IRTVvpTvGoxhbvQU1k6EtkhLcahA+MWVzNbgiIdHP\/otSQnaLW243sxoxYm7EiuAihnQ0iRaNEzsFrx\/W06G0e5rmTbWPGc4LZj6YDKd7531SGIwqOOC1wrzrZ36iuwPm5PrZReCWH3ptR6bSszQerbQsx6wkumYN7iDZg9EK9ADHRzfovbqOPad2s+N5iVWAOfEXGqItZcrLdW53vUOqbfXXuFt7szhtdvTWRWWQQJryrg61UmLgJcLb3xMMdZZ+D6mcXqa3v2cSzGdfO9123456"

--- a/tests/Functional/Features/authentication_metadata_rollover.feature
+++ b/tests/Functional/Features/authentication_metadata_rollover.feature
@@ -1,0 +1,24 @@
+Feature: When an user needs to authenticate
+  As a service provider
+  I need to send an AuthnRequest with a nameID to the Azure MFA GSSP IdP
+
+  Scenario: The user authenticates successfully if IdP is not cached
+    Given I have no cached identity provider for "institution-d.example.com"
+      And I send an authentication request to "https://azuremfa.dev.openconext.local/saml/sso" with NameID "q2b27d-0000|user@institution-d.example.com"
+      And the login with Azure MFA succeeds and the following attributes are released:
+      | name                                                       | value                     |
+      | urn:mace:dir:attribute-def:mail                            | user@institution-d.example.com |
+      | http://schemas.microsoft.com/claims/authnmethodsreferences | http://schemas.microsoft.com/claims/multipleauthn |
+    Then I should be on "https://azuremfa.dev.openconext.local/saml/sso_return"
+      And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:Success"
+      And the SAML Response should contain element "NameID" with value "q2b27d-0000|user@institution-d.example.com"
+
+  Scenario: The user authenticates successfully if IdP is cached
+    Given I send an authentication request to "https://azuremfa.dev.openconext.local/saml/sso" with NameID "q2b27d-0000|user@institution-d.example.com"
+    And the login with Azure MFA succeeds and the following attributes are released:
+      | name                                                       | value                     |
+      | urn:mace:dir:attribute-def:mail                            | user@institution-d.example.com |
+      | http://schemas.microsoft.com/claims/authnmethodsreferences | http://schemas.microsoft.com/claims/multipleauthn |
+    Then I should be on "https://azuremfa.dev.openconext.local/saml/sso_return"
+    And the SAML Response should contain element "StatusCode" with attribute "Value" with attribute value "urn:oasis:names:tc:SAML:2.0:status:Success"
+    And the SAML Response should contain element "NameID" with value "q2b27d-0000|user@institution-d.example.com"


### PR DESCRIPTION
This is done because the SAML IdentityProvider needed the `keys` array
to be able to handle multiple keys and the `certificateData` was not
meant to be used for multiple keys.

Also added a bit more logging.

https://github.com/OpenConext/Stepup-AzureMFA/issues/214