### PR TITLE
Add entrypoint to clear the federation metadata cache on startup

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -14,7 +14,7 @@ RUN tar -xvjf /tmp/*.tar.bz2 -C /var/www/html/ && \
 COPY config/openconext/parameters.yaml.dist config/openconext/parameters.yaml
 COPY config/openconext/institutions.yaml.dist config/openconext/institutions.yaml
 
-COPY ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY --chmod=755 ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Add the config files for Apache2
 RUN rm -rf /etc/apache2/sites-enabled/*

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -14,6 +14,8 @@ RUN tar -xvjf /tmp/*.tar.bz2 -C /var/www/html/ && \
 COPY config/openconext/parameters.yaml.dist config/openconext/parameters.yaml
 COPY config/openconext/institutions.yaml.dist config/openconext/institutions.yaml
 
+COPY ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
 # Add the config files for Apache2
 RUN rm -rf /etc/apache2/sites-enabled/*
 COPY ./docker/conf/azuremfa-apache2.conf /etc/apache2/sites-enabled/azuremfa.conf
@@ -23,4 +25,5 @@ EXPOSE 80
 # Set the default workdir
 WORKDIR /var/www/html
 
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -13,10 +13,13 @@ COPY config/openconext/parameters.yaml.dist config/openconext/parameters.yaml
 COPY config/openconext/institutions.yaml.dist config/openconext/institutions.yaml
 COPY config/packages/prod/monolog.yaml.docker config/packages/prod/monolog.yaml
 
+COPY ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
 # Add the config files for Apache2
 RUN rm -rf /etc/apache2/sites-enabled/* && rm -rf /var/www/html/output.zip
 COPY ./docker/conf/azuremfa-apache2.conf /etc/apache2/sites-enabled/azuremfa.conf
 RUN rm -rf /var/www/html/var/cache/prod && chown -R www-data /var/www/html/var
 EXPOSE 80
 
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -13,7 +13,7 @@ COPY config/openconext/parameters.yaml.dist config/openconext/parameters.yaml
 COPY config/openconext/institutions.yaml.dist config/openconext/institutions.yaml
 COPY config/packages/prod/monolog.yaml.docker config/packages/prod/monolog.yaml
 
-COPY ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY --chmod=755 ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Add the config files for Apache2
 RUN rm -rf /etc/apache2/sites-enabled/* && rm -rf /var/www/html/output.zip

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+PARAM_FILE="/var/www/html/config/openconext/parameters.yaml"
+CACHE_DIR=$(grep -E '^ *federation_metadata_cache_location:' "$PARAM_FILE" \
+           | cut -d ':' -f2- | tr -d '[:space:]')
+
+if [ -z "$CACHE_DIR" ]; then
+    CACHE_DIR="/var/www/html/federation-metadata"
+fi
+
+echo "Metadata cache‑map: $CACHE_DIR"
+
+if [ -d "$CACHE_DIR" ]; then
+    echo "Leegmaken van Metadata cache‑map $CACHE_DIR"
+    rm -rf "$CACHE_DIR"/* 2>/dev/null
+fi
+
+exec "$@"


### PR DESCRIPTION
This adds an entrypoint to the docker image that will clear the federation metadata cache just before the application in launched.